### PR TITLE
fix: memory leak in codelens

### DIFF
--- a/src/vs/editor/contrib/codelens/browser/codelensController.ts
+++ b/src/vs/editor/contrib/codelens/browser/codelensController.ts
@@ -395,6 +395,7 @@ export class CodeLensContribution implements IEditorContribution {
 		});
 
 		if (toResolve.length === 0) {
+			this._oldCodeLensModels.clear();
 			return;
 		}
 


### PR DESCRIPTION
In the code lens controller,the old code lens models don't seem to be cleared in all cases.  It seems they are only cleared if `toResolve.length` is greater than zero. It seems due to the early return, the cleanup from below is missing.


![code-lens-count-before](https://github.com/user-attachments/assets/69b9b3f9-335b-4f7f-99fa-50516ebc81c6)

```ts
// before
private _resolveCodeLensesInViewport(): void {

    /* ... */
    if (toResolve.length === 0) {
	    return; 
    }

    /* ... */ 
    this._oldCodeLensModels.clear();
}
```






---




 The change is to clear oldCodeLensModels in both cases:


![code-lens-count-after](https://github.com/user-attachments/assets/3e55df01-5eca-4189-bd5e-732922656808)



```ts
// after
private _resolveCodeLensesInViewport(): void {

    /* ... */
    if (toResolve.length === 0) {
		this._oldCodeLensModels.clear();
	    return; 
    }

    /* ... */ 
    this._oldCodeLensModels.clear();
}
```




