### PR TITLE
reduce memory by ~1.2 MB

### DIFF
--- a/src/vs/base/common/lifecycle.ts
+++ b/src/vs/base/common/lifecycle.ts
@@ -372,18 +372,18 @@ class FunctionDisposable implements IDisposable {
 	fn: () => void;
 
 	constructor(fn: () => void) {
-		this.isDisposed = false
-		this.fn = fn
-		trackDisposable(this)
+		this.isDisposed = false;
+		this.fn = fn;
+		trackDisposable(this);
 	}
 
 	dispose() {
 		if (this.isDisposed) {
-			return
+			return;
 		}
-		this.isDisposed = true
-		markAsDisposed(this)
-		this.fn()
+		this.isDisposed = true;
+		markAsDisposed(this);
+		this.fn();
 	}
 }
 

--- a/src/vs/base/common/lifecycle.ts
+++ b/src/vs/base/common/lifecycle.ts
@@ -367,19 +367,33 @@ export function combinedDisposable(...disposables: IDisposable[]): IDisposable {
 	return parent;
 }
 
+class FunctionDisposable implements IDisposable {
+	isDisposed: boolean;
+	fn: () => void;
+
+	constructor(fn: () => void) {
+		this.isDisposed = false
+		this.fn = fn
+		trackDisposable(this)
+	}
+
+	dispose() {
+		if (this.isDisposed) {
+			return
+		}
+		this.isDisposed = true
+		markAsDisposed(this)
+		this.fn()
+	}
+}
+
 /**
  * Turn a function that implements dispose into an {@link IDisposable}.
  *
  * @param fn Clean up function, guaranteed to be called only **once**.
  */
 export function toDisposable(fn: () => void): IDisposable {
-	const self = trackDisposable({
-		dispose: createSingleCallFunction(() => {
-			markAsDisposed(self);
-			fn();
-		})
-	});
-	return self;
+	return new FunctionDisposable(fn);
 }
 
 /**


### PR DESCRIPTION
### Overview 

This changes the `toDisposable` function to use a class so that there is one dispose function on the class prototype instead of a dispose closure created for each `toDisposable` function call.

The memory savings seem to be ~1.2 MB.

### Function overview chart

This function overview chart of vscode shows how many function instances exist of each function: 

![base](https://github.com/user-attachments/assets/60588385-ad2c-4f9f-be21-f9024e3100cc)


Notably at the top is `createSingleCallFunction`, which is used by `toDisposable`. 



### Heapsnapshot before
<img width="928" height="454" alt="before2" src="https://github.com/user-attachments/assets/41081db0-d62f-44fc-8fd2-e1b4c0fcb20e" />


### Heapsnapshot after

<img width="928" height="454" alt="after" src="https://github.com/user-attachments/assets/efbd841d-6f47-4b61-9703-c92428dc6e59" />



### Notable differences:
- The number of `Functions` is reduced from 117165 to 96305
- The number of `closures (System Context)` is reduced from 55728 to 35040
- The number of `{ dispose }` objects is reduced from 11342 to 1192
- The number of `FunctionDisposables` increases from 0 to 10087
- The memory savings seem to be ~1.2 MB.


