### PR TITLE
memory leak in decorations

### DIFF
--- a/extensions/git/src/blame.ts
+++ b/extensions/git/src/blame.ts
@@ -653,6 +653,8 @@ class GitBlameEditorDecoration implements HoverProvider {
 	}
 
 	dispose() {
+		console.log('[git] dispose decoration' + this._decoration.key)
+
 		this._hoverDisposable?.dispose();
 		this._hoverDisposable = undefined;
 

--- a/extensions/git/src/blame.ts
+++ b/extensions/git/src/blame.ts
@@ -529,8 +529,10 @@ class GitBlameEditorDecoration implements HoverProvider {
 
 	private _hoverDisposable: IDisposable | undefined;
 	private _disposables: IDisposable[] = [];
+	private _isDisposed: boolean
 
 	constructor(private readonly _controller: GitBlameController) {
+		this._isDisposed = false
 		this._decoration = window.createTextEditorDecorationType({
 			after: {
 				color: new ThemeColor('git.blame.editorDecorationForeground')
@@ -653,6 +655,7 @@ class GitBlameEditorDecoration implements HoverProvider {
 	}
 
 	dispose() {
+		this._isDisposed = true;
 		console.log('[git] dispose decoration' + this._decoration.key)
 
 		this._hoverDisposable?.dispose();

--- a/extensions/git/src/blame.ts
+++ b/extensions/git/src/blame.ts
@@ -279,9 +279,11 @@ export class GitBlameController {
 		// Editor decoration
 		if (editorDecorationEnabled) {
 			if (!this._editorDecoration) {
+				console.log('[git] add editor decoration')
 				this._editorDecoration = new GitBlameEditorDecoration(this)
 			}
 		} else {
+			console.log('[git] dispose editor decoration')
 			this._editorDecoration?.dispose();
 			this._editorDecoration = undefined;
 		}
@@ -534,6 +536,7 @@ class GitBlameEditorDecoration implements HoverProvider {
 				color: new ThemeColor('git.blame.editorDecorationForeground')
 			}
 		});
+		console.log('[git] create decoration' + this._decoration.key)
 		this._disposables.push(this._decoration);
 
 		workspace.onDidChangeConfiguration(this._onDidChangeConfiguration, this, this._disposables);

--- a/extensions/git/src/blame.ts
+++ b/extensions/git/src/blame.ts
@@ -279,7 +279,7 @@ export class GitBlameController {
 		// Editor decoration
 		if (editorDecorationEnabled) {
 			if (!this._editorDecoration) {
-				this._editorDecoration = new GitBlameEditorDecoration(this);
+				this._editorDecoration = new GitBlameEditorDecoration(this)
 			}
 		} else {
 			this._editorDecoration?.dispose();

--- a/extensions/merge-conflict/src/mergeDecorator.ts
+++ b/extensions/merge-conflict/src/mergeDecorator.ts
@@ -67,7 +67,7 @@ export default class MergeDecorator implements vscode.Disposable {
 		if (config.enableDecorations || config.enableEditorOverview) {
 			this.decorations['current.content'] = vscode.window.createTextEditorDecorationType(
 				this.generateBlockRenderOptions('merge.currentContentBackground', 'editorOverviewRuler.currentContentForeground', config)
-			);
+			)
 
 			this.decorations['incoming.content'] = vscode.window.createTextEditorDecorationType(
 				this.generateBlockRenderOptions('merge.incomingContentBackground', 'editorOverviewRuler.incomingContentForeground', config)

--- a/extensions/references-view/src/highlights.ts
+++ b/extensions/references-view/src/highlights.ts
@@ -37,6 +37,7 @@ export class EditorHighlights<T> {
 		for (const editor of vscode.window.visibleTextEditors) {
 			editor.setDecorations(this._decorationType, []);
 		}
+		this._decorationType.dispose()
 	}
 
 	private _show(): void {

--- a/src/vs/editor/browser/services/abstractCodeEditorService.ts
+++ b/src/vs/editor/browser/services/abstractCodeEditorService.ts
@@ -435,6 +435,7 @@ class DecorationSubTypeOptionsProvider implements IModelDecorationOptionsProvide
 			this._afterContentRules = null;
 		}
 		this._styleSheet.unref();
+		this._styleSheet = undefined
 	}
 }
 
@@ -621,7 +622,7 @@ export const _CSS_MAP: { [prop: string]: string } = {
 };
 
 
-class DecorationCSSRules {
+class DecorationCSSRules implements IDisposable {
 
 	private _theme: IColorTheme;
 	private readonly _className: string;

--- a/src/vs/editor/browser/services/abstractCodeEditorService.ts
+++ b/src/vs/editor/browser/services/abstractCodeEditorService.ts
@@ -435,7 +435,8 @@ class DecorationSubTypeOptionsProvider implements IModelDecorationOptionsProvide
 			this._afterContentRules = null;
 		}
 		this._styleSheet.unref();
-		this._styleSheet = undefined
+		// @ts-ignore
+		this._styleSheet = undefined;
 	}
 }
 

--- a/src/vs/editor/browser/services/abstractCodeEditorService.ts
+++ b/src/vs/editor/browser/services/abstractCodeEditorService.ts
@@ -198,6 +198,8 @@ export abstract class AbstractCodeEditorService extends Disposable implements IC
 			} else {
 				console.log(`not yet disposing provider` + key + 'due to refcount being' + provider.refCount)
 			}
+		} else {
+			console.log(`provider ` + key + ' not found')
 		}
 	}
 

--- a/src/vs/editor/browser/services/abstractCodeEditorService.ts
+++ b/src/vs/editor/browser/services/abstractCodeEditorService.ts
@@ -163,9 +163,14 @@ export abstract class AbstractCodeEditorService extends Disposable implements IC
 				options: options || Object.create(null)
 			};
 			if (!parentTypeKey) {
+				console.log('provider 1' + key)
 				provider = new DecorationTypeOptionsProvider(description, this._themeService, styleSheet, providerArgs);
 			} else {
+				console.log('provider 2' + key)
 				provider = new DecorationSubTypeOptionsProvider(this._themeService, styleSheet, providerArgs);
+			}
+			if (this._decorationOptionProviders.has(key)) {
+				throw new Error(`impossible`)
 			}
 			this._decorationOptionProviders.set(key, provider);
 			this._onDecorationTypeRegistered.fire(key);
@@ -190,6 +195,8 @@ export abstract class AbstractCodeEditorService extends Disposable implements IC
 				this._decorationOptionProviders.delete(key);
 				provider.dispose();
 				this.listCodeEditors().forEach((ed) => ed.removeDecorationsByType(key));
+			} else {
+				console.log(`not yet disposing provider` + key + 'due to refcount being' + provider.refCount)
 			}
 		}
 	}
@@ -650,6 +657,7 @@ class DecorationCSSRules implements IDisposable {
 		this._className = className;
 
 		this._unThemedSelector = CSSNameHelper.getSelector(this._providerArgs.key, this._providerArgs.parentTypeKey, ruleType);
+		console.log('unthemed selector', this._unThemedSelector);
 
 		this._buildCSS();
 
@@ -665,6 +673,7 @@ class DecorationCSSRules implements IDisposable {
 	}
 
 	public dispose() {
+		this._removeCSS();
 		if (this._hasContent) {
 			this._removeCSS();
 			this._hasContent = false;

--- a/src/vs/editor/browser/services/abstractCodeEditorService.ts
+++ b/src/vs/editor/browser/services/abstractCodeEditorService.ts
@@ -152,6 +152,7 @@ export abstract class AbstractCodeEditorService extends Disposable implements IC
 		this._editorStyleSheets.delete(editorId);
 	}
 
+	// TODO when registering subkey, it is not automatically disposed when disposing key, causing memory leak
 	public registerDecorationType(description: string, key: string, options: IDecorationRenderOptions, parentTypeKey?: string, editor?: ICodeEditor): IDisposable {
 		let provider = this._decorationOptionProviders.get(key);
 		if (!provider) {
@@ -166,7 +167,7 @@ export abstract class AbstractCodeEditorService extends Disposable implements IC
 				console.log('provider 1' + key)
 				provider = new DecorationTypeOptionsProvider(description, this._themeService, styleSheet, providerArgs);
 			} else {
-				console.log('provider 2' + key)
+				console.log('provider 2 ' + key)
 				provider = new DecorationSubTypeOptionsProvider(this._themeService, styleSheet, providerArgs);
 			}
 			if (this._decorationOptionProviders.has(key)) {

--- a/src/vs/editor/browser/services/abstractCodeEditorService.ts
+++ b/src/vs/editor/browser/services/abstractCodeEditorService.ts
@@ -747,6 +747,7 @@ class DecorationCSSRules implements IDisposable {
 	}
 
 	private _removeCSS(): void {
+		console.log(`remove css`, this._unThemedSelector)
 		this._providerArgs.styleSheet.removeRulesContainingSelector(this._unThemedSelector);
 	}
 

--- a/src/vs/editor/browser/services/codeEditorService.ts
+++ b/src/vs/editor/browser/services/codeEditorService.ts
@@ -43,7 +43,7 @@ export interface ICodeEditorService {
 	 */
 	getFocusedCodeEditor(): ICodeEditor | null;
 
-	registerDecorationType(description: string, key: string, options: IDecorationRenderOptions, parentTypeKey?: string, editor?: ICodeEditor): void;
+	registerDecorationType(description: string, key: string, options: IDecorationRenderOptions, parentTypeKey?: string, editor?: ICodeEditor): IDisposable;
 	listDecorationTypes(): string[];
 	removeDecorationType(key: string): void;
 	resolveDecorationOptions(typeKey: string, writable: boolean): IModelDecorationOptions;

--- a/src/vs/editor/browser/services/codeEditorService.ts
+++ b/src/vs/editor/browser/services/codeEditorService.ts
@@ -11,6 +11,7 @@ import { ITextResourceEditorInput } from '../../../platform/editor/common/editor
 import { createDecorator } from '../../../platform/instantiation/common/instantiation.js';
 import { URI } from '../../../base/common/uri.js';
 import { IDisposable } from '../../../base/common/lifecycle.js';
+import { IModelDecorationOptionsProviderBase } from './abstractCodeEditorService.js';
 
 export const ICodeEditorService = createDecorator<ICodeEditorService>('codeEditorService');
 
@@ -44,6 +45,8 @@ export interface ICodeEditorService {
 	getFocusedCodeEditor(): ICodeEditor | null;
 
 	registerDecorationType(description: string, key: string, options: IDecorationRenderOptions, parentTypeKey?: string, editor?: ICodeEditor): IDisposable;
+	registerDecorationSubType(description: string, key: string, options: IDecorationRenderOptions, parentTypeKey: string): void;
+	getDecorationSubTypes(key: string): Record<string, IModelDecorationOptionsProviderBase>
 	listDecorationTypes(): string[];
 	removeDecorationType(key: string): void;
 	resolveDecorationOptions(typeKey: string, writable: boolean): IModelDecorationOptions;

--- a/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
@@ -1404,11 +1404,12 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 	public setDecorationsByTypeFast(decorationTypeKey: string, ranges: IRange[]): void {
 
 		// remove decoration sub types that are no longer used, deregister decoration type if necessary
-		const oldDecorationsSubTypes = this._decorationTypeSubtypes[decorationTypeKey] || {};
+		const oldDecorationsSubTypes = this._codeEditorService.getDecorationSubTypes(decorationTypeKey)
 		for (const subType in oldDecorationsSubTypes) {
-			this._removeDecorationType(decorationTypeKey + '-' + subType);
+			const item = oldDecorationsSubTypes[subType]
+			item.dispose()
+			delete oldDecorationsSubTypes[subType]
 		}
-		this._decorationTypeSubtypes[decorationTypeKey] = {};
 
 		const opts = ModelDecorationOptions.createDynamic(this._resolveDecorationOptions(decorationTypeKey, false));
 		const newModelDecorations: IModelDeltaDecoration[] = new Array<IModelDeltaDecoration>(ranges.length);
@@ -1966,13 +1967,6 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		return model;
 	}
 
-	private _registerDecorationType(description: string, key: string, options: editorCommon.IDecorationRenderOptions, parentTypeKey?: string): IDisposable {
-		return this._codeEditorService.registerDecorationType(description, key, options, parentTypeKey, this);
-	}
-
-	private _removeDecorationType(key: string): void {
-		this._codeEditorService.removeDecorationType(key);
-	}
 
 	private _resolveDecorationOptions(typeKey: string, writable: boolean): IModelDecorationOptions {
 		return this._codeEditorService.resolveDecorationOptions(typeKey, writable);

--- a/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
@@ -1973,8 +1973,8 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		return model;
 	}
 
-	private _registerDecorationType(description: string, key: string, options: editorCommon.IDecorationRenderOptions, parentTypeKey?: string): void {
-		this._codeEditorService.registerDecorationType(description, key, options, parentTypeKey, this);
+	private _registerDecorationType(description: string, key: string, options: editorCommon.IDecorationRenderOptions, parentTypeKey?: string): IDisposable {
+		return this._codeEditorService.registerDecorationType(description, key, options, parentTypeKey, this);
 	}
 
 	private _removeDecorationType(key: string): void {

--- a/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
@@ -244,10 +244,11 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 	private _overlayWidgets: { [key: string]: IOverlayWidgetData };
 	private _glyphMarginWidgets: { [key: string]: IGlyphMarginWidgetData };
 
+
 	/**
 	 * map from "parent" decoration type to live decoration ids.
 	 */
-
+	private _decorationTypeKeysToIds: { [decorationTypeKey: string]: string[] };
 	private _bannerDomNode: HTMLElement | null = null;
 
 	private _dropIntoEditorDecorations: EditorDecorationsCollection = this.createDecorationsCollection();
@@ -273,6 +274,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 
 		const options = { ..._options };
 
+		this._decorationTypeKeysToIds = {}
 		this._domElement = domElement;
 		this._overflowWidgetsDomNode = options.overflowWidgetsDomNode;
 		delete options.overflowWidgetsDomNode;
@@ -527,15 +529,8 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 
 	private _removeDecorationTypes(): void {
 		this._decorationTypeKeysToIds = {};
-		if (this._decorationTypeSubtypes) {
-			for (const decorationType in this._decorationTypeSubtypes) {
-				const subTypes = this._decorationTypeSubtypes[decorationType];
-				for (const subType in subTypes) {
-					this._removeDecorationType(decorationType + '-' + subType);
-				}
-			}
-			this._decorationTypeSubtypes = {};
-		}
+		// TODO
+
 	}
 
 	public getVisibleRanges(): Range[] {
@@ -1435,9 +1430,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		if (this._decorationTypeKeysToIds.hasOwnProperty(decorationTypeKey)) {
 			delete this._decorationTypeKeysToIds[decorationTypeKey];
 		}
-		if (this._decorationTypeSubtypes.hasOwnProperty(decorationTypeKey)) {
-			delete this._decorationTypeSubtypes[decorationTypeKey];
-		}
+
 	}
 
 	public getLayoutInfo(): EditorLayoutInfo {

--- a/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
@@ -1358,11 +1358,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 
 		const newDecorationsSubTypes: { [key: string]: boolean } = {};
 		const oldDecorationsSubTypes = this._codeEditorService.getDecorationSubTypes(decorationTypeKey);
-		// this._decorationTypeSubtypes[decorationTypeKey] = newDecorationsSubTypes;
-
 		const newModelDecorations: IModelDeltaDecoration[] = [];
-
-
 
 		for (const decorationOption of decorationOptions) {
 			let typeKey = decorationTypeKey;

--- a/src/vs/workbench/api/browser/mainThreadEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditors.ts
@@ -358,12 +358,14 @@ export class MainThreadTextEditors implements MainThreadTextEditorsShape {
 	$registerTextEditorDecorationType(extensionId: ExtensionIdentifier, key: string, options: IDecorationRenderOptions): void {
 		key = `${this._instanceId}-${key}`;
 		this._registeredDecorationTypes[key] = true;
+		console.log('register decoration', key)
 		this._codeEditorService.registerDecorationType(`exthost-api-${extensionId}`, key, options);
 	}
 
 	$removeTextEditorDecorationType(key: string): void {
 		key = `${this._instanceId}-${key}`;
 		delete this._registeredDecorationTypes[key];
+		console.log('removde decoration', key)
 		this._codeEditorService.removeDecorationType(key);
 	}
 

--- a/src/vs/workbench/api/common/extHostTextEditor.ts
+++ b/src/vs/workbench/api/common/extHostTextEditor.ts
@@ -29,6 +29,7 @@ export class TextEditorDecorationType {
 		this.value = Object.freeze({
 			key,
 			dispose() {
+				console.log(`[ext proxy remove decoration]`+key)
 				proxy.$removeTextEditorDecorationType(key);
 			}
 		});

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -57,7 +57,7 @@ class InputEditorDecorations extends Disposable {
 	) {
 		super();
 
-		this.codeEditorService.registerDecorationType(decorationDescription, placeholderDecorationType, {});
+		this._register(this.codeEditorService.registerDecorationType(decorationDescription, placeholderDecorationType, {}));
 
 		this.registeredDecorationTypes();
 
@@ -97,29 +97,22 @@ class InputEditorDecorations extends Disposable {
 	}
 
 	private registeredDecorationTypes() {
-
-		this.codeEditorService.registerDecorationType(decorationDescription, slashCommandTextDecorationType, {
+		this._register(this.codeEditorService.registerDecorationType(decorationDescription, slashCommandTextDecorationType, {
 			color: themeColorFromId(chatSlashCommandForeground),
 			backgroundColor: themeColorFromId(chatSlashCommandBackground),
 			borderRadius: '3px'
-		});
-		this.codeEditorService.registerDecorationType(decorationDescription, variableTextDecorationType, {
+		}))
+		this._register(this.codeEditorService.registerDecorationType(decorationDescription, variableTextDecorationType, {
 			color: themeColorFromId(chatSlashCommandForeground),
 			backgroundColor: themeColorFromId(chatSlashCommandBackground),
 			borderRadius: '3px'
-		});
-		this.codeEditorService.registerDecorationType(decorationDescription, dynamicVariableDecorationType, {
+		}))
+		this._register(this.codeEditorService.registerDecorationType(decorationDescription, dynamicVariableDecorationType, {
 			color: themeColorFromId(chatSlashCommandForeground),
 			backgroundColor: themeColorFromId(chatSlashCommandBackground),
 			borderRadius: '3px',
 			rangeBehavior: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges
-		});
-
-		this._register(toDisposable(() => {
-			this.codeEditorService.removeDecorationType(variableTextDecorationType);
-			this.codeEditorService.removeDecorationType(dynamicVariableDecorationType);
-			this.codeEditorService.removeDecorationType(slashCommandTextDecorationType);
-		}));
+		}))
 	}
 
 	private getPlaceholderColor(): string | undefined {

--- a/src/vs/workbench/contrib/comments/browser/commentsController.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsController.ts
@@ -557,7 +557,7 @@ export class CommentController implements IEditorContribution {
 		}));
 
 		this.onModelChanged();
-		this.codeEditorService.registerDecorationType('comment-controller', COMMENTEDITOR_DECORATION_KEY, {});
+		this.globalToDispose.add(this.codeEditorService.registerDecorationType('comment-controller', COMMENTEDITOR_DECORATION_KEY, {}))
 		this.globalToDispose.add(
 			this.commentService.registerContinueOnCommentProvider({
 				provideContinueOnComments: () => {

--- a/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
@@ -141,7 +141,7 @@ export class BreakpointWidget extends ZoneWidget implements IPrivateBreakpointWi
 				this.dispose();
 			}
 		}));
-		this.codeEditorService.registerDecorationType('breakpoint-widget', DECORATION_KEY, {});
+		this.store.add(this.codeEditorService.registerDecorationType('breakpoint-widget', DECORATION_KEY, {}));
 
 		this.create();
 	}

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -164,7 +164,7 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 		this.replOptions = this._register(this.instantiationService.createInstance(ReplOptions, this.id, () => this.getLocationBasedColors().background));
 		this._register(this.replOptions.onDidChange(() => this.onDidStyleChange()));
 
-		codeEditorService.registerDecorationType('repl-decoration', DECORATION_KEY, {});
+		this._register(codeEditorService.registerDecorationType('repl-decoration', DECORATION_KEY, {}));
 		this.multiSessionRepl.set(this.isMultiSessionView);
 		this.registerListeners();
 	}

--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
@@ -174,7 +174,7 @@ export class InteractiveEditor extends EditorPane implements IEditorPaneWithScro
 		this._notebookOptions = instantiationService.createInstance(NotebookOptions, this.window, true, { cellToolbarInteraction: 'hover', globalToolbar: true, stickyScrollEnabled: false, dragAndDropEnabled: false, disableRulers: true });
 		this._editorMemento = this.getEditorMemento<InteractiveEditorViewState>(editorGroupService, textResourceConfigurationService, INTERACTIVE_EDITOR_VIEW_STATE_PREFERENCE_KEY);
 
-		codeEditorService.registerDecorationType('interactive-decoration', DECORATION_KEY, {});
+		this._register(codeEditorService.registerDecorationType('interactive-decoration', DECORATION_KEY, {}));
 		this._register(this._keybindingService.onDidUpdateKeybindings(this._updateInputHint, this));
 		this._register(this._notebookExecutionStateService.onDidChangeExecution((e) => {
 			if (e.type === NotebookExecutionType.cell && isEqual(e.notebook, this._notebookWidget.value?.viewModel?.notebookDocument.uri)) {

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -316,7 +316,7 @@ export class NotebookContribution extends Disposable implements IWorkbenchContri
 		}));
 
 		// register comment decoration
-		this.codeEditorService.registerDecorationType('comment-controller', COMMENTEDITOR_DECORATION_KEY, {});
+		this._register(this.codeEditorService.registerDecorationType('comment-controller', COMMENTEDITOR_DECORATION_KEY, {}));
 	}
 
 	// Add or remove the cell undo redo comparison key based on the user setting

--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -158,7 +158,7 @@ export class TestingDecorationService extends Disposable implements ITestingDeco
 		@IModelService private readonly modelService: IModelService,
 	) {
 		super();
-		codeEditorService.registerDecorationType('test-message-decoration', TestMessageDecoration.decorationId, {}, undefined);
+		this._register(codeEditorService.registerDecorationType('test-message-decoration', TestMessageDecoration.decorationId, {}, undefined));
 
 		this._register(modelService.onModelRemoved(e => this.decorationCache.delete(e.uri)));
 
@@ -394,7 +394,7 @@ export class TestingDecorations extends Disposable implements IEditorContributio
 	) {
 		super();
 
-		codeEditorService.registerDecorationType('test-message-decoration', TestMessageDecoration.decorationId, {}, undefined, editor);
+		this._register(codeEditorService.registerDecorationType('test-message-decoration', TestMessageDecoration.decorationId, {}, undefined, editor));
 
 		this.attachModel(editor.getModel()?.uri);
 		this._register(decorations.onDidChange(() => {


### PR DESCRIPTION
<!-- ⚠️⚠️ Do Not Delete This! bug_report_template ⚠️⚠️ -->
<!-- Please read our Rules of Conduct: https://opensource.microsoft.com/codeofconduct/ -->
<!-- 🕮 Read our guide about submitting issues: https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions -->
<!-- 🔎 Search existing issues to avoid creating duplicates. -->
<!-- 🧪 Test using the latest Insiders build to see if your issue has already been fixed: https://code.visualstudio.com/insiders/ -->
<!-- 💡 Instead of creating your report here, use 'Report Issue' from the 'Help' menu in VS Code to pre-fill useful information. -->
<!-- 🔧 Launch with `code --disable-extensions` to check. -->
Does this issue occur when all extensions are disabled?: Yes

<!-- 🪓 If you answered No above, use 'Help: Start Extension Bisect' from Command Palette to try to identify the cause. -->
<!-- 📣 Issues caused by an extension need to be reported directly to the extension publisher. The 'Help > Report Issue' dialog can assist with this. -->
- VS Code Version: 1.106.0
- OS Version: Ubuntu 25.10

### Steps to Reproduce

1. Create an empty git repository
2. Create a file and commit it
3. Open the file
4. Toggle Git inline blame on and off 97 times
5. Notice that the number of css rules seems to increase by one each time


### Expected behaviour

When toggling git inline blame on and off, the number of css rules stays constant.

### Actual behaviour

When toggling git inline blame on and off, the number of css rules seems to increase by one each time.


### Test Scripts (CSS rules)

Measuring CSS rules:

```sh
git clone git@github.com:SimonSiefke/vscode-memory-leak-finder.git &&
cd vscode-memory-leak-finder && 
npm ci &&
node packages/cli/bin/test.js --cwd packages/e2e --only source-control.toggle-inline-blame --run-skipped-tests-anyway   --check-leaks --measure css-rule-count --runs 97 
```

Measuring CSS rules shows these results: 

```json
{
  "cssRules": {
    "leaked": [
      ".monaco-editor .ced-1-TextEditorDecorationType142--92456b-4.ced-1-TextEditorDecorationType142-4::after { content: \"first commit\"; margin: 0px 0px 0px 50px; }",
      ".monaco-editor .ced-1-TextEditorDecorationType127--92456b-4.ced-1-TextEditorDecorationType127-4::after { content: \"first commit\"; margin: 0px 0px 0px 50px; }",
      ".monaco-editor .ced-1-TextEditorDecorationType112--92456b-4.ced-1-TextEditorDecorationType112-4::after { content: \"first commit\"; margin: 0px 0px 0px 50px; }",
      ".monaco-editor .ced-1-TextEditorDecorationType97--92456b-4.ced-1-TextEditorDecorationType97-4::after { content: \"first commit\"; margin: 0px 0px 0px 50px; }",
      ".monaco-editor .ced-1-TextEditorDecorationType82--92456b-4.ced-1-TextEditorDecorationType82-4::after { content: \"first commit\"; margin: 0px 0px 0px 50px; }",
      ".monaco-editor .ced-1-TextEditorDecorationType67--92456b-4.ced-1-TextEditorDecorationType67-4::after { content: \"first commit\"; margin: 0px 0px 0px 50px; }",
      ".monaco-editor .ced-1-TextEditorDecorationType52--92456b-4.ced-1-TextEditorDecorationType52-4::after { content: \"first commit\"; margin: 0px 0px 0px 50px; }"
    ]
  },
  "isLeak": false
}

```


### Test Scripts (Functions / Closures)

Measuring function / closure count:

```sh
git clone git@github.com:SimonSiefke/vscode-memory-leak-finder.git &&
cd vscode-memory-leak-finder && 
npm ci &&
node packages/cli/bin/test.js --cwd packages/e2e --only source-control.toggle-inline-blame --run-skipped-tests-anyway   --check-leaks --measure named-function-count3 --runs 97 
```

Measuring leaked closures shows these results as leaking closures: 

```json
{
  "namedFunctionCount3": [
    {
      "count": 124,
      "delta": 74,
      "name": "DecorationCSSRules",
      "sourceLocation": "vscode/out/vs/editor/browser/services/abstractCodeEditorService.js:468:13",
      "originalLocation": "src/vs/editor/browser/services/abstractCodeEditorService.ts:637:13",
      "originalName": "DecorationCSSRules"
    },
    {
      "count": 40,
      "delta": 37,
      "name": "DecorationSubTypeOptionsProvider",
      "sourceLocation": "vscode/out/vs/editor/browser/services/abstractCodeEditorService.js:305:13",
      "originalLocation": "src/vs/editor/browser/services/abstractCodeEditorService.ts:403:13",
      "originalName": "DecorationSubTypeOptionsProvider"
    }
  ],
  "isLeak": true
}

```