### PR TITLE
fix: memory leak in linkify

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
@@ -17,7 +17,7 @@ import { DebugLinkHoverBehaviorTypeData, ILinkDetector } from './linkDetector.js
  * @param text The content to stylize.
  * @returns An {@link HTMLSpanElement} that contains the potentially stylized text.
  */
-export function handleANSIOutput(text: string, linkDetector: ILinkDetector, workspaceFolder: IWorkspaceFolder | undefined, hoverBehavior: DebugLinkHoverBehaviorTypeData, highlights?: IHighlight[]): HTMLSpanElement {
+export function handleANSIOutput(text: string, linkDetector: ILinkDetector, workspaceFolder: IWorkspaceFolder | undefined, highlights: IHighlight[] | undefined, hoverBehavior: DebugLinkHoverBehaviorTypeData): HTMLSpanElement {
 
 	const root: HTMLSpanElement = document.createElement('span');
 	const textLength: number = text.length;
@@ -63,7 +63,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, work
 				unprintedChars += 2 + ansiSequence.length;
 
 				// Flush buffer with previous styles.
-				appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, hoverBehavior, currentPos - buffer.length - unprintedChars, highlights);
+				appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, currentPos - buffer.length - unprintedChars, highlights, hoverBehavior);
 				buffer = '';
 
 				/*
@@ -108,7 +108,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, work
 
 	// Flush remaining text buffer if not empty.
 	if (buffer) {
-		appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, highlights, currentPos - buffer.length, highlights);
+		appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, currentPos - buffer.length, highlights, hoverBehavior);
 	}
 
 	return root;

--- a/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
@@ -400,7 +400,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, work
  * @param customUnderlineColor If provided, will apply custom textDecorationColor with inline style.
  * @param highlights The ranges to highlight.
  * @param offset The starting index of the stringContent in the original text.
- * @param hoverBehavior Optional hover behavior with disposable store for managing event listeners.
+ * @param hoverBehavior hover behavior with disposable store for managing event listeners.
  */
 export function appendStylizedStringToContainer(
 	root: HTMLElement,

--- a/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
@@ -11,13 +11,13 @@ import { registerThemingParticipant } from '../../../../platform/theme/common/th
 import { IWorkspaceFolder } from '../../../../platform/workspace/common/workspace.js';
 import { PANEL_BACKGROUND, SIDE_BAR_BACKGROUND } from '../../../common/theme.js';
 import { ansiColorIdentifiers } from '../../terminal/common/terminalColorRegistry.js';
-import { ILinkDetector } from './linkDetector.js';
+import { DebugLinkHoverBehaviorTypeData, ILinkDetector } from './linkDetector.js';
 
 /**
  * @param text The content to stylize.
  * @returns An {@link HTMLSpanElement} that contains the potentially stylized text.
  */
-export function handleANSIOutput(text: string, linkDetector: ILinkDetector, workspaceFolder: IWorkspaceFolder | undefined, highlights: IHighlight[] | undefined): HTMLSpanElement {
+export function handleANSIOutput(text: string, linkDetector: ILinkDetector, workspaceFolder: IWorkspaceFolder | undefined, hoverBehavior: DebugLinkHoverBehaviorTypeData, highlights?: IHighlight[]): HTMLSpanElement {
 
 	const root: HTMLSpanElement = document.createElement('span');
 	const textLength: number = text.length;
@@ -63,7 +63,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, work
 				unprintedChars += 2 + ansiSequence.length;
 
 				// Flush buffer with previous styles.
-				appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, highlights, currentPos - buffer.length - unprintedChars);
+				appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, highlights, highlights, highlights, currentPos - buffer.length - unprintedChars);
 
 				buffer = '';
 
@@ -109,7 +109,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, work
 
 	// Flush remaining text buffer if not empty.
 	if (buffer) {
-		appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, highlights, currentPos - buffer.length);
+		appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, hoverBehavior, highlights, currentPos - buffer.length,);
 	}
 
 	return root;
@@ -401,6 +401,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, work
  * @param customUnderlineColor If provided, will apply custom textDecorationColor with inline style.
  * @param highlights The ranges to highlight.
  * @param offset The starting index of the stringContent in the original text.
+ * @param hoverBehavior Optional hover behavior with disposable store for managing event listeners.
  */
 export function appendStylizedStringToContainer(
 	root: HTMLElement,
@@ -411,8 +412,9 @@ export function appendStylizedStringToContainer(
 	customTextColor: RGBA | string | undefined,
 	customBackgroundColor: RGBA | string | undefined,
 	customUnderlineColor: RGBA | string | undefined,
-	highlights: IHighlight[] | undefined,
 	offset: number,
+	highlights: IHighlight[] | undefined,
+	hoverBehavior: DebugLinkHoverBehaviorTypeData,
 ): void {
 	if (!root || !stringContent) {
 		return;
@@ -420,9 +422,9 @@ export function appendStylizedStringToContainer(
 
 	const container = linkDetector.linkify(
 		stringContent,
+		hoverBehavior,
 		true,
 		workspaceFolder,
-		undefined,
 		undefined,
 		highlights?.map(h => ({ start: h.start - offset, end: h.end - offset, extraClasses: h.extraClasses })),
 	);

--- a/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
@@ -63,7 +63,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, work
 				unprintedChars += 2 + ansiSequence.length;
 
 				// Flush buffer with previous styles.
-				appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, currentPos - buffer.length - unprintedChars, highlights, hoverBehavior);
+				appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, highlights, currentPos - buffer.length - unprintedChars, hoverBehavior);
 				buffer = '';
 
 				/*
@@ -108,7 +108,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, work
 
 	// Flush remaining text buffer if not empty.
 	if (buffer) {
-		appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, currentPos - buffer.length, highlights, hoverBehavior);
+		appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, highlights, currentPos - buffer.length, hoverBehavior);
 	}
 
 	return root;
@@ -411,8 +411,8 @@ export function appendStylizedStringToContainer(
 	customTextColor: RGBA | string | undefined,
 	customBackgroundColor: RGBA | string | undefined,
 	customUnderlineColor: RGBA | string | undefined,
-	offset: number,
 	highlights: IHighlight[] | undefined,
+	offset: number,
 	hoverBehavior: DebugLinkHoverBehaviorTypeData,
 ): void {
 	if (!root || !stringContent) {

--- a/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
@@ -63,8 +63,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, work
 				unprintedChars += 2 + ansiSequence.length;
 
 				// Flush buffer with previous styles.
-				appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, highlights, highlights, highlights, currentPos - buffer.length - unprintedChars);
-
+				appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, hoverBehavior, currentPos - buffer.length - unprintedChars, highlights);
 				buffer = '';
 
 				/*
@@ -109,7 +108,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, work
 
 	// Flush remaining text buffer if not empty.
 	if (buffer) {
-		appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, hoverBehavior, highlights, currentPos - buffer.length,);
+		appendStylizedStringToContainer(root, buffer, styleNames, linkDetector, workspaceFolder, customFgColor, customBgColor, customUnderlineColor, highlights, currentPos - buffer.length, highlights);
 	}
 
 	return root;

--- a/src/vs/workbench/contrib/debug/browser/debugExpressionRenderer.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugExpressionRenderer.ts
@@ -187,7 +187,7 @@ export class DebugExpressionRenderer {
 		}
 
 		if (supportsANSI) {
-			container.appendChild(handleANSIOutput(value, linkDetector, session ? session.root : undefined, hoverBehavior, options.highlights));
+			container.appendChild(handleANSIOutput(value, linkDetector, session ? session.root : undefined, options.highlights, hoverBehavior));
 		} else {
 			container.appendChild(linkDetector.linkify(value, hoverBehavior, false, session?.root, true, options.highlights));
 		}
@@ -202,7 +202,7 @@ export class DebugExpressionRenderer {
 				if (supportsANSI) {
 					// note: intentionally using `this.linkDetector` so we don't blindly linkify the
 					// entire contents and instead only link file paths that it contains.
-					hoverContentsPre.appendChild(handleANSIOutput(value, this.linkDetector, session ? session.root : undefined, hoverBehavior, options.highlights));
+					hoverContentsPre.appendChild(handleANSIOutput(value, this.linkDetector, session ? session.root : undefined, options.highlights, hoverBehavior));
 				} else {
 					hoverContentsPre.textContent = value;
 				}

--- a/src/vs/workbench/contrib/debug/browser/debugExpressionRenderer.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugExpressionRenderer.ts
@@ -177,7 +177,7 @@ export class DebugExpressionRenderer {
 
 		const session = options.session ?? ((expressionOrValue instanceof ExpressionContainer) ? expressionOrValue.getSession() : undefined);
 		// Only use hovers for links if thre's not going to be a hover for the value.
-		const hoverBehavior: DebugLinkHoverBehaviorTypeData = options.hover === false ? { type: DebugLinkHoverBehavior.Rich, store } : { type: DebugLinkHoverBehavior.None };
+		const hoverBehavior: DebugLinkHoverBehaviorTypeData = options.hover === false ? { type: DebugLinkHoverBehavior.Rich, store } : { type: DebugLinkHoverBehavior.None, store };
 		dom.clearNode(container);
 		const locationReference = options.locationReference ?? (expressionOrValue instanceof ExpressionContainer && expressionOrValue.valueLocationReference);
 
@@ -187,9 +187,9 @@ export class DebugExpressionRenderer {
 		}
 
 		if (supportsANSI) {
-			container.appendChild(handleANSIOutput(value, linkDetector, session ? session.root : undefined, options.highlights));
+			container.appendChild(handleANSIOutput(value, linkDetector, session ? session.root : undefined, hoverBehavior, options.highlights));
 		} else {
-			container.appendChild(linkDetector.linkify(value, false, session?.root, true, hoverBehavior, options.highlights));
+			container.appendChild(linkDetector.linkify(value, hoverBehavior, false, session?.root, true, options.highlights));
 		}
 
 		if (options.hover !== false) {
@@ -202,7 +202,7 @@ export class DebugExpressionRenderer {
 				if (supportsANSI) {
 					// note: intentionally using `this.linkDetector` so we don't blindly linkify the
 					// entire contents and instead only link file paths that it contains.
-					hoverContentsPre.appendChild(handleANSIOutput(value, this.linkDetector, session ? session.root : undefined, options.highlights));
+					hoverContentsPre.appendChild(handleANSIOutput(value, this.linkDetector, session ? session.root : undefined, hoverBehavior, options.highlights));
 				} else {
 					hoverContentsPre.textContent = value;
 				}

--- a/src/vs/workbench/contrib/debug/test/browser/debugANSIHandling.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/debugANSIHandling.test.ts
@@ -84,7 +84,7 @@ suite('Debug - ANSI Handling', () => {
 	 */
 	function getSequenceOutput(sequence: string): HTMLSpanElement {
 		const hoverBehavior = { type: DebugLinkHoverBehavior.None, store: new DisposableStore() };
-		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, session.root, hoverBehavior, []);
+		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, session.root, [], hoverBehavior);
 		assert.strictEqual(1, root.children.length);
 		const child: Node = root.lastChild!;
 		if (isHTMLSpanElement(child)) {
@@ -398,7 +398,7 @@ suite('Debug - ANSI Handling', () => {
 			elementsExpected = assertions.length;
 		}
 		const hoverBehavior = { type: DebugLinkHoverBehavior.None, store: new DisposableStore() };
-		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, session.root, hoverBehavior, []);
+		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, session.root, [], hoverBehavior);
 		assert.strictEqual(elementsExpected, root.children.length);
 		for (let i = 0; i < elementsExpected; i++) {
 			const child: Node = root.children[i];

--- a/src/vs/workbench/contrib/debug/test/browser/debugANSIHandling.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/debugANSIHandling.test.ts
@@ -87,6 +87,7 @@ suite('Debug - ANSI Handling', () => {
 		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, session.root, [], hoverBehavior);
 		assert.strictEqual(1, root.children.length);
 		const child: Node = root.lastChild!;
+		hoverBehavior.store.dispose();
 		if (isHTMLSpanElement(child)) {
 			return child;
 		} else {

--- a/src/vs/workbench/contrib/debug/test/browser/debugANSIHandling.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/debugANSIHandling.test.ts
@@ -14,7 +14,7 @@ import { workbenchInstantiationService } from '../../../../test/browser/workbenc
 import { registerColors } from '../../../terminal/common/terminalColorRegistry.js';
 import { appendStylizedStringToContainer, calcANSI8bitColor, handleANSIOutput } from '../../browser/debugANSIHandling.js';
 import { DebugSession } from '../../browser/debugSession.js';
-import { LinkDetector } from '../../browser/linkDetector.js';
+import { DebugLinkHoverBehavior, LinkDetector } from '../../browser/linkDetector.js';
 import { DebugModel } from '../../common/debugModel.js';
 import { createTestSession } from './callStack.test.js';
 import { createMockDebugModel } from './mockDebugModel.js';
@@ -51,8 +51,9 @@ suite('Debug - ANSI Handling', () => {
 
 		assert.strictEqual(0, root.children.length);
 
-		appendStylizedStringToContainer(root, 'content1', ['class1', 'class2'], linkDetector, session.root, undefined, undefined, undefined, undefined, 0);
-		appendStylizedStringToContainer(root, 'content2', ['class2', 'class3'], linkDetector, session.root, undefined, undefined, undefined, undefined, 0);
+		const hoverBehavior = { type: DebugLinkHoverBehavior.None, store: new DisposableStore() };
+		appendStylizedStringToContainer(root, 'content1', ['class1', 'class2'], linkDetector, session.root, undefined, undefined, undefined, undefined, 0, hoverBehavior);
+		appendStylizedStringToContainer(root, 'content2', ['class2', 'class3'], linkDetector, session.root, undefined, undefined, undefined, undefined, 0, hoverBehavior);
 
 		assert.strictEqual(2, root.children.length);
 
@@ -82,7 +83,8 @@ suite('Debug - ANSI Handling', () => {
 	 * @returns An {@link HTMLSpanElement} that contains the stylized text.
 	 */
 	function getSequenceOutput(sequence: string): HTMLSpanElement {
-		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, session.root, []);
+		const hoverBehavior = { type: DebugLinkHoverBehavior.None, store: new DisposableStore() };
+		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, session.root, hoverBehavior, []);
 		assert.strictEqual(1, root.children.length);
 		const child: Node = root.lastChild!;
 		if (isHTMLSpanElement(child)) {
@@ -395,7 +397,8 @@ suite('Debug - ANSI Handling', () => {
 		if (elementsExpected === undefined) {
 			elementsExpected = assertions.length;
 		}
-		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, session.root, []);
+		const hoverBehavior = { type: DebugLinkHoverBehavior.None, store: new DisposableStore() };
+		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, session.root, hoverBehavior, []);
 		assert.strictEqual(elementsExpected, root.children.length);
 		for (let i = 0; i < elementsExpected; i++) {
 			const child: Node = root.children[i];

--- a/src/vs/workbench/contrib/debug/test/browser/linkDetector.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/linkDetector.test.ts
@@ -5,13 +5,14 @@
 
 import assert from 'assert';
 import { isHTMLAnchorElement } from '../../../../../base/browser/dom.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { isWindows } from '../../../../../base/common/platform.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ITunnelService } from '../../../../../platform/tunnel/common/tunnel.js';
 import { WorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
-import { LinkDetector } from '../../browser/linkDetector.js';
+import { DebugLinkHoverBehavior, LinkDetector } from '../../browser/linkDetector.js';
 import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 import { IHighlight } from '../../../../../base/browser/ui/highlightedlabel/highlightedLabel.js';
 
@@ -28,6 +29,10 @@ suite('Debug - Link Detector', () => {
 		instantiationService.stub(ITunnelService, { canTunnel: () => false });
 		linkDetector = instantiationService.createInstance(LinkDetector);
 	});
+
+	function createHoverBehavior() {
+		return { type: DebugLinkHoverBehavior.None, store: new DisposableStore() };
+	}
 
 	/**
 	 * Assert that a given Element is an anchor element.

--- a/src/vs/workbench/contrib/debug/test/browser/linkDetector.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/linkDetector.test.ts
@@ -46,7 +46,8 @@ suite('Debug - Link Detector', () => {
 	test('noLinks', () => {
 		const input = 'I am a string';
 		const expectedOutput = '<span>I am a string</span>';
-		const output = linkDetector.linkify(input);
+		const hoverBehavior = createHoverBehavior();
+		const output = linkDetector.linkify(input, hoverBehavior);
 
 		assert.strictEqual(0, output.children.length);
 		assert.strictEqual('SPAN', output.tagName);

--- a/src/vs/workbench/contrib/debug/test/browser/linkDetector.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/linkDetector.test.ts
@@ -48,7 +48,6 @@ suite('Debug - Link Detector', () => {
 	test('noLinks', () => {
 		const input = 'I am a string';
 		const expectedOutput = '<span>I am a string</span>';
-		const hoverBehavior = createHoverBehavior();
 		const output = linkDetector.linkify(input, hoverBehavior);
 
 		assert.strictEqual(0, output.children.length);

--- a/src/vs/workbench/contrib/debug/test/browser/linkDetector.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/linkDetector.test.ts
@@ -58,7 +58,6 @@ suite('Debug - Link Detector', () => {
 	test('trailingNewline', () => {
 		const input = 'I am a string\n';
 		const expectedOutput = '<span>I am a string\n</span>';
-		const hoverBehavior = createHoverBehavior();
 		const output = linkDetector.linkify(input, hoverBehavior);
 
 		assert.strictEqual(0, output.children.length);
@@ -69,7 +68,6 @@ suite('Debug - Link Detector', () => {
 	test('trailingNewlineSplit', () => {
 		const input = 'I am a string\n';
 		const expectedOutput = '<span>I am a string\n</span>';
-		const hoverBehavior = createHoverBehavior();
 		const output = linkDetector.linkify(input, hoverBehavior, true);
 
 		assert.strictEqual(0, output.children.length);
@@ -80,7 +78,6 @@ suite('Debug - Link Detector', () => {
 	test('singleLineLink', () => {
 		const input = isWindows ? 'C:\\foo\\bar.js:12:34' : '/Users/foo/bar.js:12:34';
 		const expectedOutput = isWindows ? '<span><a tabindex="0">C:\\foo\\bar.js:12:34<\/a><\/span>' : '<span><a tabindex="0">/Users/foo/bar.js:12:34<\/a><\/span>';
-		const hoverBehavior = createHoverBehavior();
 		const output = linkDetector.linkify(input, hoverBehavior);
 
 		assert.strictEqual(1, output.children.length);
@@ -94,7 +91,6 @@ suite('Debug - Link Detector', () => {
 	test('relativeLink', () => {
 		const input = '\./foo/bar.js';
 		const expectedOutput = '<span>\./foo/bar.js</span>';
-		const hoverBehavior = createHoverBehavior();
 		const output = linkDetector.linkify(input, hoverBehavior);
 
 		assert.strictEqual(0, output.children.length);
@@ -104,7 +100,6 @@ suite('Debug - Link Detector', () => {
 
 	test('relativeLinkWithWorkspace', async () => {
 		const input = '\./foo/bar.js';
-		const hoverBehavior = createHoverBehavior();
 		const output = linkDetector.linkify(input, hoverBehavior, false, new WorkspaceFolder({ uri: URI.file('/path/to/workspace'), name: 'ws', index: 0 }));
 		assert.strictEqual('SPAN', output.tagName);
 		assert.ok(output.outerHTML.indexOf('link') >= 0);
@@ -113,7 +108,6 @@ suite('Debug - Link Detector', () => {
 	test('singleLineLinkAndText', function () {
 		const input = isWindows ? 'The link: C:/foo/bar.js:12:34' : 'The link: /Users/foo/bar.js:12:34';
 		const expectedOutput = /^<span>The link: <a tabindex="0">.*\/foo\/bar.js:12:34<\/a><\/span>$/;
-		const hoverBehavior = createHoverBehavior();
 		const output = linkDetector.linkify(input, hoverBehavior);
 
 		assert.strictEqual(1, output.children.length);
@@ -128,7 +122,6 @@ suite('Debug - Link Detector', () => {
 		const input = isWindows ? 'Here is a link C:/foo/bar.js:12:34 and here is another D:/boo/far.js:56:78' :
 			'Here is a link /Users/foo/bar.js:12:34 and here is another /Users/boo/far.js:56:78';
 		const expectedOutput = /^<span>Here is a link <a tabindex="0">.*\/foo\/bar.js:12:34<\/a> and here is another <a tabindex="0">.*\/boo\/far.js:56:78<\/a><\/span>$/;
-		const hoverBehavior = createHoverBehavior();
 		const output = linkDetector.linkify(input, hoverBehavior);
 
 		assert.strictEqual(2, output.children.length);
@@ -145,7 +138,6 @@ suite('Debug - Link Detector', () => {
 	test('multilineNoLinks', () => {
 		const input = 'Line one\nLine two\nLine three';
 		const expectedOutput = /^<span><span>Line one\n<\/span><span>Line two\n<\/span><span>Line three<\/span><\/span>$/;
-		const hoverBehavior = createHoverBehavior();
 		const output = linkDetector.linkify(input, hoverBehavior, true);
 
 		assert.strictEqual(3, output.children.length);
@@ -159,7 +151,6 @@ suite('Debug - Link Detector', () => {
 	test('multilineTrailingNewline', () => {
 		const input = 'I am a string\nAnd I am another\n';
 		const expectedOutput = '<span><span>I am a string\n<\/span><span>And I am another\n<\/span><\/span>';
-		const hoverBehavior = createHoverBehavior();
 		const output = linkDetector.linkify(input, hoverBehavior, true);
 
 		assert.strictEqual(2, output.children.length);
@@ -173,7 +164,6 @@ suite('Debug - Link Detector', () => {
 		const input = isWindows ? 'I have a link for you\nHere it is: C:/foo/bar.js:12:34\nCool, huh?' :
 			'I have a link for you\nHere it is: /Users/foo/bar.js:12:34\nCool, huh?';
 		const expectedOutput = /^<span><span>I have a link for you\n<\/span><span>Here it is: <a tabindex="0">.*\/foo\/bar.js:12:34<\/a>\n<\/span><span>Cool, huh\?<\/span><\/span>$/;
-		const hoverBehavior = createHoverBehavior();
 		const output = linkDetector.linkify(input, hoverBehavior, true);
 
 		assert.strictEqual(3, output.children.length);
@@ -191,7 +181,6 @@ suite('Debug - Link Detector', () => {
 		const input = 'I am a string';
 		const highlights: IHighlight[] = [{ start: 2, end: 5 }];
 		const expectedOutput = '<span>I <span class="highlight">am </span>a string</span>';
-		const hoverBehavior = createHoverBehavior();
 		const output = linkDetector.linkify(input, hoverBehavior, false, undefined, false, highlights);
 
 		assert.strictEqual(1, output.children.length);
@@ -203,7 +192,6 @@ suite('Debug - Link Detector', () => {
 		const input = isWindows ? 'C:\\foo\\bar.js:12:34' : '/Users/foo/bar.js:12:34';
 		const highlights: IHighlight[] = [{ start: 0, end: 5 }];
 		const expectedOutput = isWindows ? '<span><a tabindex="0"><span class="highlight">C:\\fo</span>o\\bar.js:12:34</a></span>' : '<span><a tabindex="0"><span class="highlight">/User</span>s/foo/bar.js:12:34</a></span>';
-		const hoverBehavior = createHoverBehavior();
 		const output = linkDetector.linkify(input, hoverBehavior, false, undefined, false, highlights);
 
 		assert.strictEqual(1, output.children.length);
@@ -217,7 +205,6 @@ suite('Debug - Link Detector', () => {
 		const input = isWindows ? 'C:\\foo\\bar.js:12:34' : '/Users/foo/bar.js:12:34';
 		const highlights: IHighlight[] = [{ start: 0, end: 10 }];
 		const expectedOutput = isWindows ? '<span><a tabindex="0"><span class="highlight">C:\\foo\\bar</span>.js:12:34</a></span>' : '<span><a tabindex="0"><span class="highlight">/Users/foo</span>/bar.js:12:34</a></span>';
-		const hoverBehavior = createHoverBehavior();
 		const output = linkDetector.linkify(input, hoverBehavior, false, undefined, false, highlights);
 
 		assert.strictEqual(1, output.children.length);
@@ -231,7 +218,6 @@ suite('Debug - Link Detector', () => {
 		const input = isWindows ? 'C:\\foo\\bar.js:12:34' : '/Users/foo/bar.js:12:34';
 		const highlights: IHighlight[] = [{ start: 10, end: 20 }];
 		const expectedOutput = isWindows ? '<span><a tabindex="0">C:\\foo\\bar<span class="highlight">.js:12:34</span></a></span>' : '<span><a tabindex="0">/Users/foo<span class="highlight">/bar.js:12</span>:34</a></span>';
-		const hoverBehavior = createHoverBehavior();
 		const output = linkDetector.linkify(input, hoverBehavior, false, undefined, false, highlights);
 
 		assert.strictEqual(1, output.children.length);
@@ -245,7 +231,6 @@ suite('Debug - Link Detector', () => {
 		const input = isWindows ? 'C:\\foo\\bar.js:12:34' : '/Users/foo/bar.js:12:34';
 		const highlights: IHighlight[] = [{ start: 5, end: 15 }];
 		const expectedOutput = isWindows ? '<span><a tabindex="0">C:\\fo<span class="highlight">o\\bar.js:1</span>2:34</a></span>' : '<span><a tabindex="0">/User<span class="highlight">s/foo/bar.</span>js:12:34</a></span>';
-		const hoverBehavior = createHoverBehavior();
 		const output = linkDetector.linkify(input, hoverBehavior, false, undefined, false, highlights);
 
 		assert.strictEqual(1, output.children.length);


### PR DESCRIPTION
Fixes a memory leak in `linkDetector.ts` by replacing `HTMLElement.onclick` with `dom.addDisposableListener('click')`.

Because of that, now the disposable store also needs to be passed from one function to another and another.  But the main change is replacing `HTMLElement.onclick` with `dom.addDisposableListener('click')`.

### Before

A `keydown`, `click`, `mouseleave` and `mousemove` event listener leak related to `linkDetector` are found: 

```json
{
  "eventListenersWithStackTrace": [
    {
      "type": "keydown",
      "description": "l=>{const c=new Li(l);(c.keyCode===3||c.keyCode===10)&&(c.preventDefault(),c.stopPropagation(),r(c.keyCode===10))}",
      "objectId": "-6136671504294265107.1.22263",
      "count": 133,
      "originalStack": ["src/vs/workbench/contrib/debug/browser/linkDetector.ts:338:19"],
      "originalName": "e"
    },
    {
      "type": "click",
      "description": "l=>{const c=Te(e).getSelection();!c||c.type===\"Range\"||(Ye?l.metaKey:l.ctrlKey)&&(l.preventDefault(),l.stopImmediatePropagation(),r(!1))}",
      "objectId": "-6136671504294265107.1.22261",
      "count": 133,
      "originalStack": ["src/vs/workbench/contrib/debug/browser/linkDetector.ts:325:18"],
      "originalName": "event"
    },
    {
      "type": "mouseleave",
      "description": "()=>e.classList.remove(\"pointer\")",
      "objectId": "-6136671504294265107.1.22259",
      "count": 133,
      "originalStack": ["src/vs/workbench/contrib/debug/browser/linkDetector.ts:324:22"],
      "originalName": null
    },
    {
      "type": "mousemove",
      "description": "l=>{e.classList.toggle(\"pointer\",Ye?l.metaKey:l.ctrlKey)}",
      "objectId": "-6136671504294265107.1.22257",
      "count": 133,
      "originalStack": ["src/vs/workbench/contrib/debug/browser/linkDetector.ts:323:22"],
      "originalName": "event"
    }
  ],
  "isLeak": true
}

```


### After

No more leak is detected.