### PR TITLE
fix: memory leak in notebook editor widget

### DIFF
--- a/src/vs/editor/common/editorContextKeys.ts
+++ b/src/vs/editor/common/editorContextKeys.ts
@@ -60,6 +60,9 @@ export namespace EditorContextKeys {
 
 	export const standaloneColorPickerVisible = new RawContextKey<boolean>('standaloneColorPickerVisible', false, nls.localize('standaloneColorPickerVisible', "Whether the standalone color picker is visible"));
 	export const standaloneColorPickerFocused = new RawContextKey<boolean>('standaloneColorPickerFocused', false, nls.localize('standaloneColorPickerFocused', "Whether the standalone color picker is focused"));
+
+	export const isComposing = new RawContextKey<boolean>('isComposing', false, nls.localize('isComposing', "Whether the editor is in the composition mode"));
+
 	/**
 	 * A context key that is set when an editor is part of a larger editor, like notebooks or
 	 * (future) a diff editor

--- a/src/vs/editor/contrib/find/browser/findController.ts
+++ b/src/vs/editor/contrib/find/browser/findController.ts
@@ -1107,7 +1107,7 @@ registerEditorCommand(new FindCommand({
 	handler: x => x.replace(),
 	kbOpts: {
 		weight: KeybindingWeight.EditorContrib + 5,
-		kbExpr: ContextKeyExpr.and(EditorContextKeys.focus, CONTEXT_REPLACE_INPUT_FOCUSED),
+		kbExpr: ContextKeyExpr.and(EditorContextKeys.focus, CONTEXT_REPLACE_INPUT_FOCUSED, ContextKeyExpr.not('isComposing')),
 		primary: KeyCode.Enter
 	}
 }));

--- a/src/vs/editor/contrib/find/browser/findController.ts
+++ b/src/vs/editor/contrib/find/browser/findController.ts
@@ -1107,7 +1107,7 @@ registerEditorCommand(new FindCommand({
 	handler: x => x.replace(),
 	kbOpts: {
 		weight: KeybindingWeight.EditorContrib + 5,
-		kbExpr: ContextKeyExpr.and(EditorContextKeys.focus, CONTEXT_REPLACE_INPUT_FOCUSED, ContextKeyExpr.not('isComposing')),
+		kbExpr: ContextKeyExpr.and(EditorContextKeys.focus, CONTEXT_REPLACE_INPUT_FOCUSED, EditorContextKeys.isComposing.negate()),
 		primary: KeyCode.Enter
 	}
 }));

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -29,7 +29,7 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Color, RGBA } from '../../../../base/common/color.js';
 import { onUnexpectedError } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { combinedDisposable, Disposable, DisposableStore, dispose } from '../../../../base/common/lifecycle.js';
+import { combinedDisposable, Disposable, DisposableStore, dispose, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { setTimeout0 } from '../../../../base/common/platform.js';
 import { extname, isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -1516,16 +1516,17 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		}));
 
 		let hasPendingChangeContentHeight = false;
+		const renderScrollHeightDisposable = this._localStore.add(new MutableDisposable());
 		this._localStore.add(this._list.onDidChangeContentHeight(() => {
 			if (hasPendingChangeContentHeight) {
 				return;
 			}
 			hasPendingChangeContentHeight = true;
 
-			this._localStore.add(DOM.scheduleAtNextAnimationFrame(DOM.getWindow(this.getDomNode()), () => {
+			renderScrollHeightDisposable.value = DOM.scheduleAtNextAnimationFrame(DOM.getWindow(this.getDomNode()), () => {
 				hasPendingChangeContentHeight = false;
 				this._updateScrollHeight();
-			}, 100));
+			}, 100);
 		}));
 
 		this._localStore.add(this._list.onDidRemoveOutputs(outputs => {

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -56,6 +56,7 @@ import { IUserDataProfileService } from '../../userDataProfile/common/userDataPr
 import { IUserKeybindingItem, KeybindingIO, OutputBuilder } from '../common/keybindingIO.js';
 import { IKeyboard, INavigatorWithKeyboard } from './navigatorKeyboard.js';
 import { getAllUnboundCommands } from './unboundCommands.js';
+import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
 
 function isValidContributedKeyBinding(keyBinding: ContributedKeyBinding, rejects: string[]): boolean {
 	if (!keyBinding) {
@@ -199,7 +200,7 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 	) {
 		super(contextKeyService, commandService, telemetryService, notificationService, logService);
 
-		this.isComposingGlobalContextKey = contextKeyService.createKey('isComposing', false);
+		this.isComposingGlobalContextKey = contextKeyService.createKey(EditorContextKeys.isComposing.key, false);
 
 		this.kbsJsonSchema = new KeybindingsJsonSchema();
 		this.updateKeybindingsJsonSchema();


### PR DESCRIPTION
Fixes a memory leak in notebookEditorWidget.

### Details


In notebookEditorWidget, when the list height changes, the scrollheight is updated. And each time the list changes height, a new disposable is added to `this._localStore`, making the number of disposables grow by one each time the list content height changes:

```ts
this._localStore.add(this._list.onDidChangeContentHeight(() => {
		this._localStore.add(DOM.scheduleAtNextAnimationFrame(DOM.getWindow(this.getDomNode()), () => {
			hasPendingChangeContentHeight = false;
			this._updateScrollHeight();
		}, 100));
}));
```
### Change

The change uses a `MutableDisposable` so that there can be at most one disposable for the animation frame registered


```ts
const renderScrollHeightDisposable = this._localStore.add(new MutableDisposable());

this._localStore.add(this._list.onDidChangeContentHeight(() => {
		renderScrollHeightDisposable.value = DOM.scheduleAtNextAnimationFrame(DOM.getWindow(this.getDomNode()), () => {
			hasPendingChangeContentHeight = false;
			this._updateScrollHeight();
		}, 100);
}));
```

### Before

When executing a notebook cell 37, the number of functions in `AnimationFrameQueueItem` and `NotebookEditorWidget` seems to grow by one each time:

<img width="1400" height="240" alt="Untitled" src="https://github.com/user-attachments/assets/1113b26d-0f88-411a-b0fa-431f58bdba60" />




### After

When executing a notebook cell 37, the number of `AnimationFrameQueueItem` stays constant (only some things link `UndoGroup` and `StackOperations` grow, which seems fine):

![notebook-execute-cell](https://github.com/user-attachments/assets/633021c1-0465-48b5-91e5-d404d3cd6d12)