### PR TITLE
fix: memory leak in ipc

### DIFF
--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -517,12 +517,6 @@ export class ChannelServer<TContext = string> implements IChannelServer<TContext
 		}
 		dispose(this.activeRequests.values());
 		this.activeRequests.clear();
-		// for (const requests of this.pendingRequests.values()) {
-		// 	for (const request of requests) {
-		// 		clearTimeout(request.timeoutTimer);
-		// 	}
-		// }
-		// this.pendingRequests.clear();
 	}
 }
 
@@ -786,8 +780,6 @@ export class ChannelClient implements IChannelClient, IDisposable {
 		}
 		dispose(this.activeRequests.values());
 		this.activeRequests.clear();
-		// this._onDidInitialize.dispose();
-		// this.handlers.clear();
 	}
 }
 
@@ -852,14 +844,14 @@ export class IPCServer<TContext = string> implements IChannelServer<TContext>, I
 					channelClient.dispose();
 					this._connections.delete(connection);
 					this._onDidRemoveConnection.fire(connection);
-					this.disposables.delete(connectionDisposables)
+					this.disposables.delete(connectionDisposables);
 					connectionDisposables.dispose();
 				}));
 			});
 
 			connectionDisposables.add(onFirstMessageDisposable);
 			connectionDisposables.add(onDidClientDisconnect(() => {
-				this.disposables.delete(connectionDisposables)
+				this.disposables.delete(connectionDisposables);
 				connectionDisposables.dispose();
 			}));
 

--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -517,12 +517,12 @@ export class ChannelServer<TContext = string> implements IChannelServer<TContext
 		}
 		dispose(this.activeRequests.values());
 		this.activeRequests.clear();
-		for (const requests of this.pendingRequests.values()) {
-			for (const request of requests) {
-				clearTimeout(request.timeoutTimer);
-			}
-		}
-		this.pendingRequests.clear();
+		// for (const requests of this.pendingRequests.values()) {
+		// 	for (const request of requests) {
+		// 		clearTimeout(request.timeoutTimer);
+		// 	}
+		// }
+		// this.pendingRequests.clear();
 	}
 }
 
@@ -786,8 +786,8 @@ export class ChannelClient implements IChannelClient, IDisposable {
 		}
 		dispose(this.activeRequests.values());
 		this.activeRequests.clear();
-		this._onDidInitialize.dispose();
-		this.handlers.clear();
+		// this._onDidInitialize.dispose();
+		// this.handlers.clear();
 	}
 }
 

--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -850,11 +850,6 @@ export class IPCServer<TContext = string> implements IChannelServer<TContext>, I
 			});
 
 			connectionDisposables.add(onFirstMessageDisposable);
-			connectionDisposables.add(onDidClientDisconnect(() => {
-				this.disposables.delete(connectionDisposables);
-				connectionDisposables.dispose();
-			}));
-
 			this.disposables.add(connectionDisposables);
 		}));
 	}


### PR DESCRIPTION
Fixes a memory leak in ipc. 


### Details

In ipc in the `onDidClientConnect` callback, two disposables are registered to `this.disposables`: 
1. `this.disposables.add(onFirstMessage(msg => {`
2.  `this.disposables.add(onDidClientDisconnect(() => {`

When a client connects and then disconnects, the disposables registered by 1. and 2. don't seem to be disposed. 

Example: When a new window is opened and closed, first the window client connects `onDidClientConnect`, then `onFirstMessage` and the `onDidClientDisconnect` listeners are set up. When the window is closed, `onDidClientDisconnect` fires. But the `onFirstMessage` and `onDidClientDisconnect` are not removed, only when the `IPCServer` disposes.



### Change

The change is not adding the disposables 1. and 2. to `this.disposables`. But instead to a separate `connectionDisposable`. The `connectionDisposable` is disposed when the client disconnects. 

That way, when a client connects and disconnects, no extra disposables remain in `this.disposables`


### Before 

When opening and closing a window 17 times, the number of `ChannelClient`, `ChannelServer` and `IpcMain` functions seems to grow each time:

<img width="1400" height="1840" alt="shapes at 26-02-09 17 00 05" src="https://github.com/user-attachments/assets/6b2fd8a6-9b62-490f-ad36-f835ea66d61b" />







### After

When opening and closing a window 17 times, the number of `ChannelClient`, `ChannelServer` and `IpcMainImpl` functions stays constant:

![window-open-new](https://github.com/user-attachments/assets/3686cbb2-72ee-4465-bb8a-38cbca8f83f7)


