### PR TITLE
fix: memory leak in policy ipc

### DIFF
--- a/src/vs/platform/policy/common/policyIpc.ts
+++ b/src/vs/platform/policy/common/policyIpc.ts
@@ -53,7 +53,7 @@ export class PolicyChannelClient extends AbstractPolicyService implements IPolic
 				this.policies.set(name, value);
 			}
 		}
-		this.channel.listen<object>('onDidChange')(policies => {
+		this._register(this.channel.listen<object>('onDidChange')(policies => {
 			for (const name in policies) {
 				const value = policies[name as keyof typeof policies];
 
@@ -65,7 +65,7 @@ export class PolicyChannelClient extends AbstractPolicyService implements IPolic
 			}
 
 			this._onDidChange.fire(Object.keys(policies));
-		});
+		}));
 	}
 
 	protected async _updatePolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): Promise<void> {

--- a/src/vs/platform/policy/common/policyIpc.ts
+++ b/src/vs/platform/policy/common/policyIpc.ts
@@ -56,7 +56,7 @@ export class PolicyChannelClient extends AbstractPolicyService implements IPolic
 				this.policies.set(name, value);
 			}
 		}
-		this._register(this.channel.listen<object>('onDidChange')(policies => {
+		this.channel.listen<object>('onDidChange')(policies => {
 			for (const name in policies) {
 				const value = policies[name as keyof typeof policies];
 
@@ -68,7 +68,7 @@ export class PolicyChannelClient extends AbstractPolicyService implements IPolic
 			}
 
 			this._onDidChange.fire(Object.keys(policies));
-		}));
+		});
 	}
 
 	protected async _updatePolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): Promise<void> {

--- a/src/vs/platform/policy/common/policyIpc.ts
+++ b/src/vs/platform/policy/common/policyIpc.ts
@@ -14,13 +14,13 @@ import { AbstractPolicyService, IPolicyService, PolicyDefinition, PolicyValue } 
 export class PolicyChannel implements IServerChannel {
 
 	private readonly _onDidChange: Event<object>;
-	private readonly _disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 
 	constructor(private service: IPolicyService) {
 		this._onDidChange = Event.map(
 			this.service.onDidChange,
 			names => names.reduce<object>((r, name) => ({ ...r, [name]: this.service.getPolicyValue(name) ?? null }), {}),
-			this._disposables
+			this.disposables
 		);
 	}
 
@@ -41,7 +41,7 @@ export class PolicyChannel implements IServerChannel {
 	}
 
 	dispose() {
-		this._disposables.dispose();
+		this.disposables.dispose();
 	}
 }
 


### PR DESCRIPTION
Fixes a memory leaks in policy ipc.


### Details

There exists only one `PolicyChannelServer` and multiple `PolicyChannelClients`. Currenly, when a client listens, an event disposable gets the `PolicyChannelServer` disposables. But it doesn't seem to be removed when the client disconnects or gets disposed. 


```ts
listen(_: unknown, event: string): Event<any> {
	switch (event) {
		case 'onDidChange': return Event.map(
			this.service.onDidChange,
			names => names.reduce<object>((r, name) => ({ ...r, [name]: this.service.getPolicyValue(name) ?? null }), {}),
			this.disposables // here
		);
	}
}
```

### Change

By moving the `_onDidChange` event creation to the constructor, the event disposables are only added once to `this.disposables`. When a client listens, disposables are added to `this.disposables`.

### Before

When opening and closing a window 17 times, the number of functions in `PolicyChannel.listen` seems to grow each time:
<img width="2305" height="2628" alt="shapes at 26-02-09 18 52 55" src="https://github.com/user-attachments/assets/a5f736b3-4e87-404e-b0f0-041d57feba6e" />


### After

When opening and closing a window 17 times, the number of functions in `PolicyChannel.listen` stays constant:

![window-open-new](https://github.com/user-attachments/assets/ad3e187a-c799-46b5-ad47-bad0235dd17f)



