### PR TITLE
fix: memory leak in utilityProcessWorkerMainService

### DIFF
--- a/src/vs/platform/utilityProcess/electron-main/utilityProcess.ts
+++ b/src/vs/platform/utilityProcess/electron-main/utilityProcess.ts
@@ -440,12 +440,12 @@ export class UtilityProcess extends Disposable {
 			UtilityProcess.all.delete(this.processPid);
 		}
 
-		if (this.process) {
-			// @ts-ignore
-			this.process.stdout?.destroy();
-			// @ts-ignore
-			this.process.stderr?.destroy();
-		}
+		// if (this.process) {
+		// 	// @ts-ignore
+		// 	// this.process.stdout?.destroy();
+		// 	// // @ts-ignore
+		// 	// this.process.stderr?.destroy();
+		// }
 
 		this.process = undefined;
 	}

--- a/src/vs/platform/utilityProcess/electron-main/utilityProcess.ts
+++ b/src/vs/platform/utilityProcess/electron-main/utilityProcess.ts
@@ -440,13 +440,6 @@ export class UtilityProcess extends Disposable {
 			UtilityProcess.all.delete(this.processPid);
 		}
 
-		// if (this.process) {
-		// 	// @ts-ignore
-		// 	// this.process.stdout?.destroy();
-		// 	// // @ts-ignore
-		// 	// this.process.stderr?.destroy();
-		// }
-
 		this.process = undefined;
 	}
 

--- a/src/vs/platform/utilityProcess/electron-main/utilityProcess.ts
+++ b/src/vs/platform/utilityProcess/electron-main/utilityProcess.ts
@@ -440,6 +440,13 @@ export class UtilityProcess extends Disposable {
 			UtilityProcess.all.delete(this.processPid);
 		}
 
+		if (this.process) {
+			// @ts-ignore
+			this.process.stdout?.destroy();
+			// @ts-ignore
+			this.process.stderr?.destroy();
+		}
+
 		this.process = undefined;
 	}
 

--- a/src/vs/platform/utilityProcess/electron-main/utilityProcessWorkerMainService.ts
+++ b/src/vs/platform/utilityProcess/electron-main/utilityProcessWorkerMainService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable } from '../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap } from '../../../base/common/lifecycle.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { ILogService } from '../../log/common/log.js';
 import { IUtilityProcessWorkerCreateConfiguration, IOnDidTerminateUtilityrocessWorkerProcess, IUtilityProcessWorkerConfiguration, IUtilityProcessWorkerProcessExit, IUtilityProcessWorkerService } from '../common/utilityProcessWorkerService.js';
@@ -26,7 +26,7 @@ export class UtilityProcessWorkerMainService extends Disposable implements IUtil
 
 	declare readonly _serviceBrand: undefined;
 
-	private readonly workers = new Map<number /* id */, UtilityProcessWorker>();
+	private readonly workers = this._register(new DisposableMap<number /* id */, UtilityProcessWorker>());
 
 	constructor(
 		@ILogService private readonly logService: ILogService,
@@ -65,7 +65,7 @@ export class UtilityProcessWorkerMainService extends Disposable implements IUtil
 				this.logService.error(`[UtilityProcessWorker]: terminated unexpectedly with code ${reason.code}, signal: ${reason.signal}`);
 			}
 
-			this.workers.delete(workerId);
+			this.workers.deleteAndDispose(workerId);
 			onDidTerminate.complete({ reason });
 		});
 
@@ -88,9 +88,7 @@ export class UtilityProcessWorkerMainService extends Disposable implements IUtil
 
 		this.logService.trace(`[UtilityProcessWorker]: disposeWorker(window: ${configuration.reply.windowId}, moduleId: ${configuration.process.moduleId})`);
 
-		worker.kill();
-		worker.dispose();
-		this.workers.delete(workerId);
+		this.workers.deleteAndDispose(workerId);
 	}
 }
 

--- a/src/vs/platform/utilityProcess/electron-main/utilityProcessWorkerMainService.ts
+++ b/src/vs/platform/utilityProcess/electron-main/utilityProcessWorkerMainService.ts
@@ -87,8 +87,7 @@ export class UtilityProcessWorkerMainService extends Disposable implements IUtil
 		}
 
 		this.logService.trace(`[UtilityProcessWorker]: disposeWorker(window: ${configuration.reply.windowId}, moduleId: ${configuration.process.moduleId})`);
-
-		this.workers.deleteAndDispose(workerId);
+		worker.kill();
 	}
 }
 


### PR DESCRIPTION
Fixes a memory leak in `utilityProcessWorkerMainService`.

### Details

In `utilityProcessWorkerMainService`, when a worker is terminated, it is removed from the `this.workers` map. But the worker itself seems be not be disposed.

```ts
Event.once(worker.onDidTerminate)(reason => {
    /* ... */
	this.workers.delete(workerId);
	onDidTerminate.complete({ reason });
});
```

### Change

The change uses a `DisposableMap` so that the worker is be deleted from the map and also gets disposed. 

```ts

Event.once(worker.onDidTerminate)(reason => {
	/* ... */
	this.workers.deleteAndDispose(workerId);
	onDidTerminate.complete({ reason });
});
```

<br>


Another related (but not really important) change is removing some cleanup code from `disposeWorker` which seems to be already handled by `worker.onDidTerminate`. 

```ts
worker.kill();
 ̶w̶o̶r̶k̶e̶r̶.̶d̶i̶s̶p̶o̶s̶e̶(̶)̶;̶
̶t̶h̶i̶s̶.̶w̶o̶r̶k̶e̶r̶s̶.̶d̶e̶l̶e̶t̶e̶(̶w̶o̶r̶k̶e̶r̶I̶d̶)̶;̶
```

### Before

<img width="1400" height="1820" alt="shapes at 26-02-09 21 12 07" src="https://github.com/user-attachments/assets/b3506a12-fca8-410f-9129-3e5277f18ea5" />


When opening and closing a window 17 times, the number of various utility process functions seems to grow each time. 





### After

When opening and closing a window 17 times, the number of utility process functions stays constant:

![window-open-new-10](https://github.com/user-attachments/assets/0ca8194f-f4e7-4c6f-916f-eb97fb36dea6)

