### PR TITLE
fix: memory leak in settings-tree

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1008,6 +1008,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 
 	protected renderSettingElement(node: ITreeNode<SettingsTreeSettingElement, never>, index: number, template: ISettingItemTemplate | ISettingBoolItemTemplate): void {
 		const element = node.element;
+		template.elementDisposables.clear();
 
 		// The element must inspect itself to get information for
 		// the modified indicator and the overridden Settings indicators.

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -950,7 +950,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 		const deprecationWarningElement = DOM.append(container, $('.setting-item-deprecation-message'));
 
 		const toolbarContainer = DOM.append(container, $('.setting-toolbar-container'));
-		const toolbar = this.renderSettingToolbar(toolbarContainer);
+		const toolbar = toDispose.add(this.renderSettingToolbar(toolbarContainer));
 
 		const template: ISettingItemTemplate = {
 			toDispose,

--- a/src/vs/workbench/contrib/preferences/test/browser/settingsTree.test.ts
+++ b/src/vs/workbench/contrib/preferences/test/browser/settingsTree.test.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ITreeNode } from '../../../../../base/browser/ui/tree/tree.js';
+import { ToolBar } from '../../../../../base/browser/ui/toolbar/toolbar.js';
+import { IAction } from '../../../../../base/common/actions.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { ISetting } from '../../../../services/preferences/common/preferences.js';
+import { SettingsTarget } from '../../browser/preferencesWidgets.js';
+import { AbstractSettingRenderer } from '../../browser/settingsTree.js';
+import { SettingsTreeSettingElement } from '../../browser/settingsTreeModels.js';
+
+class TestSettingRenderer extends AbstractSettingRenderer {
+	readonly templateId = 'test';
+	toolbarDisposed = false;
+
+	constructor() {
+		super(
+			[],
+			(_setting: ISetting, _settingTarget: SettingsTarget): IAction[] => [],
+			undefined!,
+			undefined!,
+			undefined!,
+			{ createInstance: () => ({ dispose() { } }) } as never,
+			undefined!,
+			undefined!,
+			undefined!,
+			new TestConfigurationService(),
+			undefined!,
+			undefined!,
+			undefined!,
+			undefined!,
+			{ setupDelayedHover: () => Disposable.None } as never,
+			undefined!,
+		);
+	}
+
+	renderTemplate(container: HTMLElement) {
+		return this.renderCommonTemplate(undefined, container, 'test');
+	}
+
+	renderElement(_element: ITreeNode<SettingsTreeSettingElement, never>, _index: number, _templateData: unknown): void {
+	}
+
+	protected override renderSettingToolbar(_container: HTMLElement): ToolBar {
+		return {
+			dispose: () => this.toolbarDisposed = true
+		} as unknown as ToolBar;
+	}
+
+	protected renderValue(): void {
+	}
+}
+
+suite('SettingsTree renderer', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('disposes the setting toolbar with its template', () => {
+		const renderer = new TestSettingRenderer();
+		const template = renderer.renderTemplate(document.createElement('div'));
+
+		assert.strictEqual(renderer.toolbarDisposed, false);
+		renderer.disposeTemplate(template);
+		assert.strictEqual(renderer.toolbarDisposed, true);
+
+		renderer.dispose();
+	});
+});


### PR DESCRIPTION
### Details

Opening and moving Settings from its modal editor retained every settings row toolbar through `HoverService._managedHovers`. Each toolbar kept its editor group, `ModalEditorPart`, and the entire Settings tree alive.

### Change

Register each settings row `ToolBar` with the template disposable store so destroying the template disposes the toolbar and its managed hover.

### Before

When `settings-open.ts` was run for 37 iterations with `named-function-count3`, 84,998 Settings-related allocations remained, including 79,452 `SettingsTreeSettingElement`, 4,140 `SettingsTreeGroupElement`, 37 `SettingsEditor2`, and 37 `ModalEditorPart` allocations:

<img width="1400" height="5300" alt="settings-open before" src="https://github.com/user-attachments/assets/b940e84f-23f9-4613-ba23-4a718380623c" />

### After

No more matching Settings tree/editor leak is detected. The same 37-run measure reports zero Settings tree, `SettingsEditor2`, or `ModalEditorPart` leak rows; ten unrelated rows remain:

<img width="1400" height="180" alt="settings-open after" src="https://github.com/user-attachments/assets/0da94103-b0ae-4ba8-802b-6fda7fba2c91" />

### Test Video

[settings-open.webm](https://github.com/user-attachments/assets/59924fff-9815-4663-8100-1c4fbc011332)
