### PR TITLE
fix: memory leak in LoggerChannel

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -1303,7 +1303,7 @@ export class CodeApplication extends Disposable {
 		mainProcessElectronServer.registerChannel(McpGatewayChannelName, mcpGatewayChannel);
 
 		// Logger
-		const loggerChannel = new LoggerChannel(accessor.get(ILoggerMainService),);
+		const loggerChannel = this._register(new LoggerChannel(accessor.get(ILoggerMainService)));
 		mainProcessElectronServer.registerChannel('logger', loggerChannel);
 		sharedProcessClient.then(client => client.registerChannel('logger', loggerChannel));
 

--- a/src/vs/platform/log/electron-main/logIpc.ts
+++ b/src/vs/platform/log/electron-main/logIpc.ts
@@ -17,6 +17,11 @@ export class LoggerChannel extends Disposable implements IServerChannel {
 
 	constructor(private readonly loggerService: ILoggerMainService) {
 		super();
+		this._register(this.loggerService.onDidChangeLoggers(({ removed }) => {
+			for (const loggerResource of removed) {
+				this.loggers.deleteAndDispose(loggerResource.resource);
+			}
+		}));
 	}
 
 	listen(_: unknown, event: string, windowId?: number): Event<any> {
@@ -36,7 +41,7 @@ export class LoggerChannel extends Disposable implements IServerChannel {
 			case 'setLogLevel': return isLogLevel(arg[0]) ? this.loggerService.setLogLevel(arg[0]) : this.loggerService.setLogLevel(URI.revive(arg[0]), arg[1]);
 			case 'setVisibility': return this.loggerService.setVisibility(URI.revive(arg[0]), arg[1]);
 			case 'registerLogger': return this.loggerService.registerLogger({ ...arg[0], resource: URI.revive(arg[0].resource) }, arg[1]);
-			case 'deregisterLogger': return this.deregisterLogger(URI.revive(arg[0]));
+			case 'deregisterLogger': return this.loggerService.deregisterLogger(URI.revive(arg[0]));
 		}
 
 		throw new Error(`Call not found: ${command}`);
@@ -44,11 +49,6 @@ export class LoggerChannel extends Disposable implements IServerChannel {
 
 	private createLogger(file: URI, options: ILoggerOptions, windowId: number | undefined): void {
 		this.loggers.set(file, this.loggerService.createLogger(file, options, windowId));
-	}
-
-	private deregisterLogger(file: URI): void {
-		this.loggers.deleteAndDispose(file);
-		this.loggerService.deregisterLogger(file);
 	}
 
 	private consoleLog(level: LogLevel, args: any[]): void {

--- a/src/vs/platform/log/electron-main/logIpc.ts
+++ b/src/vs/platform/log/electron-main/logIpc.ts
@@ -6,15 +6,18 @@
 import { Event } from '../../../base/common/event.js';
 import { ResourceMap } from '../../../base/common/map.js';
 import { URI } from '../../../base/common/uri.js';
+import { Disposable, DisposableMap } from '../../../base/common/lifecycle.js';
 import { IServerChannel } from '../../../base/parts/ipc/common/ipc.js';
 import { ILogger, ILoggerOptions, isLogLevel, log, LogLevel } from '../common/log.js';
 import { ILoggerMainService } from './loggerService.js';
 
-export class LoggerChannel implements IServerChannel {
+export class LoggerChannel extends Disposable implements IServerChannel {
 
-	private readonly loggers = new ResourceMap<ILogger>();
+	private readonly loggers = this._register(new DisposableMap(new ResourceMap<ILogger>()));
 
-	constructor(private readonly loggerService: ILoggerMainService) { }
+	constructor(private readonly loggerService: ILoggerMainService) {
+		super();
+	}
 
 	listen(_: unknown, event: string, windowId?: number): Event<any> {
 		switch (event) {
@@ -33,7 +36,7 @@ export class LoggerChannel implements IServerChannel {
 			case 'setLogLevel': return isLogLevel(arg[0]) ? this.loggerService.setLogLevel(arg[0]) : this.loggerService.setLogLevel(URI.revive(arg[0]), arg[1]);
 			case 'setVisibility': return this.loggerService.setVisibility(URI.revive(arg[0]), arg[1]);
 			case 'registerLogger': return this.loggerService.registerLogger({ ...arg[0], resource: URI.revive(arg[0].resource) }, arg[1]);
-			case 'deregisterLogger': return this.loggerService.deregisterLogger(URI.revive(arg[0]));
+			case 'deregisterLogger': return this.deregisterLogger(URI.revive(arg[0]));
 		}
 
 		throw new Error(`Call not found: ${command}`);
@@ -41,6 +44,11 @@ export class LoggerChannel implements IServerChannel {
 
 	private createLogger(file: URI, options: ILoggerOptions, windowId: number | undefined): void {
 		this.loggers.set(file, this.loggerService.createLogger(file, options, windowId));
+	}
+
+	private deregisterLogger(file: URI): void {
+		this.loggers.deleteAndDispose(file);
+		this.loggerService.deregisterLogger(file);
 	}
 
 	private consoleLog(level: LogLevel, args: any[]): void {
@@ -71,4 +79,3 @@ export class LoggerChannel implements IServerChannel {
 		}
 	}
 }
-

--- a/src/vs/platform/log/electron-main/logIpc.ts
+++ b/src/vs/platform/log/electron-main/logIpc.ts
@@ -79,3 +79,4 @@ export class LoggerChannel extends Disposable implements IServerChannel {
 		}
 	}
 }
+


### PR DESCRIPTION
Fixes a memory leak in LoggerChannel.

### Details


The createLogger function creates `Logger` instances and stores them in `this.loggers`. 

```ts
private createLogger(file: URI, options: ILoggerOptions, windowId: number | undefined): void {
  this.loggers.set(file, this.loggerService.createLogger(file, options, windowId));
}
```

But in `deregisterLogger` it seems to not remove and dispose the logger from `this.loggers`.

```ts
async call(_: unknown, command: string, arg?: any): Promise<any> {
  switch (command) {
     /* ... */
    case 'deregisterLogger': return this.loggerService.deregisterLogger(URI.revive(arg[0])); // doesn't remove this.loggers[uri]
}
```


### Change

The change tries to ensure that when a logger deregistered/removed, that the matching entry from `this.loggers` is also gets removed. 

 

```ts
export class LoggerChannel extends Disposable implements IServerChannel {

	private readonly loggers = this._register(new DisposableMap(new ResourceMap<ILogger>()));

	constructor(private readonly loggerService: ILoggerMainService) {
		super();
       /*  Ensure to remove loggers this.loggers map */ 
		this._register(this.loggerService.onDidChangeLoggers(({ removed }) => {
			for (const loggerResource of removed) {
				this.loggers.deleteAndDispose(loggerResource.resource);
			}
		}));
	}

```


<br>

This also makes the `LoggerChannel` class extend the `Disposable`  now and therefore changes `app.ts` to use `this._register`:

```ts
// app.ts

const loggerChannel = this._register(new LoggerChannel(accessor.get(ILoggerMainService)));
```

### Before


When opening and closing a new window 17 times, the number of various functions seems to grow each time:

<img width="1400" height="400" alt="logIpc" src="https://github.com/user-attachments/assets/7b271bb6-3ef2-4d2f-a63b-ed60dc3f9455" />


### After

When opening and closing a new window 17 times the number of various functions still grows, but no more `ResourceMapEntry` leak and no more `SpdLogLogger` leak is detected.

<img width="1400" height="360" alt="window-open-new 9" src="https://github.com/user-attachments/assets/3955f747-f83f-4d86-b71a-7c563812baad" />



