### PR TITLE
fix: memory leak in storageMainService

### DIFF
--- a/src/vs/platform/storage/electron-main/storageMainService.ts
+++ b/src/vs/platform/storage/electron-main/storageMainService.ts
@@ -17,7 +17,7 @@ import { AbstractStorageService, isProfileUsingDefaultStorage, IStorageService, 
 import { ApplicationStorageMain, ApplicationSharedStorageMain, ProfileStorageMain, InMemoryStorageMain, IStorageMain, IStorageMainOptions, WorkspaceStorageMain, IStorageChangeEvent } from './storageMain.js';
 import { IUserDataProfile, IUserDataProfilesService } from '../../userDataProfile/common/userDataProfile.js';
 import { IUserDataProfilesMainService } from '../../userDataProfile/electron-main/userDataProfile.js';
-import { IAnyWorkspaceIdentifier } from '../../workspace/common/workspace.js';
+import { IAnyWorkspaceIdentifier, toWorkspaceIdentifier } from '../../workspace/common/workspace.js';
 import { IUriIdentityService } from '../../uriIdentity/common/uriIdentity.js';
 import { Schemas } from '../../../base/common/network.js';
 
@@ -131,6 +131,20 @@ export class StorageMainService extends Disposable implements IStorageMainServic
 			if (e.workspace) {
 				this.workspaceStorage(e.workspace).init();
 			}
+
+
+			Event.once(Event.any(e.window.onDidClose, e.window.onDidDestroy))(async () => {
+				if (this.shutdownReason) {
+					return;
+				}
+				if (e.window.profile && this.mapProfileToStorage.has(e.window.profile.id)) {
+					await this.profileStorage(e.window.profile).close();
+				}
+				const actualWorkspace = e.workspace ?? e.window.openedWorkspace ?? toWorkspaceIdentifier(e.window.backupPath, e.window.isExtensionDevelopmentHost);
+				if (actualWorkspace && this.mapWorkspaceToStorage.has(actualWorkspace.id)) {
+					await this.workspaceStorage(actualWorkspace).close();
+				}
+			});
 		}));
 
 		// All Storage: Close when shutting down
@@ -230,7 +244,7 @@ export class StorageMainService extends Disposable implements IStorageMainServic
 		if (!profileStorage) {
 			this.logService.trace(`StorageMainService: creating profile storage (${profile.name})`);
 
-			profileStorage = this._register(this.createProfileStorage(profile));
+			profileStorage = this.createProfileStorage(profile);
 			this.mapProfileToStorage.set(profile.id, profileStorage);
 
 			// Don't use this._register() for listeners that are disposed early
@@ -277,7 +291,7 @@ export class StorageMainService extends Disposable implements IStorageMainServic
 		if (!workspaceStorage) {
 			this.logService.trace(`StorageMainService: creating workspace storage (${workspace.id})`);
 
-			workspaceStorage = this._register(this.createWorkspaceStorage(workspace));
+			workspaceStorage = this.createWorkspaceStorage(workspace);
 			this.mapWorkspaceToStorage.set(workspace.id, workspaceStorage);
 
 			// Don't use this._register() for Event.once as it auto-disposes


### PR DESCRIPTION
Fixes a memory leak in storageMainService. 

### Details

In `storageMainService`, when a window is loaded, the profile storage and workspace storage for that window are intialized:


```ts
this._register(this.lifecycleMainService.onWillLoadWindow(e => {

	// Profile Storage: Warmup when related window with profile loads
	if (e.window.profile) {
		this.profileStorage(e.window.profile).init();
	}

	// Workspace Storage: Warmup when related window with workspace loads
	if (e.workspace) {
		this.workspaceStorage(e.workspace).init();
	}
}
```


But it seems the profile storage and workspace storage aren't being closed their window closes.


### Changes

The change ensures when a window is closed, that its profile storage and workspace storage are closed as well: 

```ts

this._register(this.lifecycleMainService.onWillLoadWindow(e => {

	// Profile Storage: Warmup when related window with profile loads
	if (e.window.profile) {
		this.profileStorage(e.window.profile).init();
	}

	// Workspace Storage: Warmup when related window with workspace loads
	if (e.workspace) {
		this.workspaceStorage(e.workspace).init();
	}


	Event.once(Event.any(e.window.onDidClose, e.window.onDidDestroy))(async () => {
		if (this.shutdownReason) {
			return;
		}
		if (e.window.profile && this.mapProfileToStorage.has(e.window.profile.id)) {
			await this.profileStorage(e.window.profile).close();
		}
		const actualWorkspace = e.workspace ?? e.window.openedWorkspace ?? toWorkspaceIdentifier(e.window.backupPath, e.window.isExtensionDevelopmentHost);
		if (actualWorkspace && this.mapWorkspaceToStorage.has(actualWorkspace.id)) {
			await this.workspaceStorage(actualWorkspace).close();
		}
	});
}));
```


<hr>


Also this code 

```ts
workspaceStorage = this._register(this.createWorkspaceStorage(workspace));
this.mapWorkspaceToStorage.set(workspace.id, workspaceStorage);
```

is changed to 

```ts
workspaceStorage = this.createWorkspaceStorage(workspace);
this.mapWorkspaceToStorage.set(workspace.id, workspaceStorage);
```

because adding the storage disposables via `this._register` would only remove them when the `storageMainService` shuts down. instead of when the window closes.
 

### Before

When opening and closing a new window 17 times, the number of storageMainService functions seems to grow each time:
<img width="1400" height="220" alt="window-open-new 0" src="https://github.com/user-attachments/assets/b63f3f1e-8023-4f5b-8a03-8e226dfd55f4" />


### After

When opening and closing a new window 17 times, the number of storageMainService function stays constant:


<img width="1400" height="20" alt="window-open-new" src="https://github.com/user-attachments/assets/84cdae35-2f32-47ca-9c46-82b9449fd0f3" />