### PR TITLE
fix: process leaks in extensionHostConnection

### DIFF
--- a/src/vs/server/node/extensionHostConnection.ts
+++ b/src/vs/server/node/extensionHostConnection.ts
@@ -170,17 +170,32 @@ export class ExtensionHostConnection extends Disposable {
 			disposables.dispose();
 		};
 
-		disposables.add(connectionData.socket.onEnd(stopAndCleanup));
-		disposables.add(connectionData.socket.onClose(stopAndCleanup));
+		let didEndExtensionHostSocket = false;
+		let extensionHostToRendererDataListener = Disposable.None;
+		const endExtensionHostSocket = () => {
+			if (didEndExtensionHostSocket) {
+				return;
+			}
+			didEndExtensionHostSocket = true;
+			extensionHostToRendererDataListener.dispose();
+			connectionData.socket.dispose();
+			if (!extHostSocket.destroyed && !extHostSocket.writableEnded) {
+				extHostSocket.end();
+			}
+		};
+
+		disposables.add(connectionData.socket.onEnd(endExtensionHostSocket));
+		disposables.add(connectionData.socket.onClose(endExtensionHostSocket));
 
 		disposables.add(Event.fromNodeEventEmitter<void>(extHostSocket, 'end')(stopAndCleanup));
 		disposables.add(Event.fromNodeEventEmitter<void>(extHostSocket, 'close')(stopAndCleanup));
 		disposables.add(Event.fromNodeEventEmitter<void>(extHostSocket, 'error')(stopAndCleanup));
 
 		disposables.add(connectionData.socket.onData((e) => extHostSocket.write(e.buffer)));
-		disposables.add(Event.fromNodeEventEmitter<Buffer>(extHostSocket, 'data')((e) => {
+		extensionHostToRendererDataListener = Event.fromNodeEventEmitter<Buffer>(extHostSocket, 'data')((e) => {
 			connectionData.socket.write(VSBuffer.wrap(e));
-		}));
+		});
+		disposables.add(extensionHostToRendererDataListener);
 
 		if (connectionData.initialDataChunk.byteLength > 0) {
 			extHostSocket.write(connectionData.initialDataChunk.buffer);

--- a/src/vs/server/node/extensionHostConnection.ts
+++ b/src/vs/server/node/extensionHostConnection.ts
@@ -163,39 +163,26 @@ export class ExtensionHostConnection extends Disposable {
 		const disposables = new DisposableStore();
 		disposables.add(connectionData.socket);
 		disposables.add(toDisposable(() => {
-			extHostSocket.destroy();
+			if (!extHostSocket.destroyed && !extHostSocket.writableEnded) {
+				extHostSocket.end();
+			}
 		}));
 
 		const stopAndCleanup = () => {
 			disposables.dispose();
 		};
 
-		let didEndExtensionHostSocket = false;
-		let extensionHostToRendererDataListener = Disposable.None;
-		const endExtensionHostSocket = () => {
-			if (didEndExtensionHostSocket) {
-				return;
-			}
-			didEndExtensionHostSocket = true;
-			extensionHostToRendererDataListener.dispose();
-			connectionData.socket.dispose();
-			if (!extHostSocket.destroyed && !extHostSocket.writableEnded) {
-				extHostSocket.end();
-			}
-		};
-
-		disposables.add(connectionData.socket.onEnd(endExtensionHostSocket));
-		disposables.add(connectionData.socket.onClose(endExtensionHostSocket));
+		disposables.add(connectionData.socket.onEnd(stopAndCleanup));
+		disposables.add(connectionData.socket.onClose(stopAndCleanup));
 
 		disposables.add(Event.fromNodeEventEmitter<void>(extHostSocket, 'end')(stopAndCleanup));
 		disposables.add(Event.fromNodeEventEmitter<void>(extHostSocket, 'close')(stopAndCleanup));
 		disposables.add(Event.fromNodeEventEmitter<void>(extHostSocket, 'error')(stopAndCleanup));
 
 		disposables.add(connectionData.socket.onData((e) => extHostSocket.write(e.buffer)));
-		extensionHostToRendererDataListener = Event.fromNodeEventEmitter<Buffer>(extHostSocket, 'data')((e) => {
+		disposables.add(Event.fromNodeEventEmitter<Buffer>(extHostSocket, 'data')((e) => {
 			connectionData.socket.write(VSBuffer.wrap(e));
-		});
-		disposables.add(extensionHostToRendererDataListener);
+		}));
 
 		if (connectionData.initialDataChunk.byteLength > 0) {
 			extHostSocket.write(connectionData.initialDataChunk.buffer);

--- a/src/vs/workbench/api/node/extensionHostProcess.ts
+++ b/src/vs/workbench/api/node/extensionHostProcess.ts
@@ -242,21 +242,13 @@ function _createExtHostProtocol(): Promise<IMessagePassingProtocol> {
 						clearTimeout(timer);
 						protocol = new PersistentProtocol({ socket, initialChunk: initialDataChunk });
 						protocol.sendResume();
-						let didDisconnect = false;
-						Event.once(protocol.onDidDispose)(() => {
-							didDisconnect = true;
-							disconnectRunner1.cancel();
-							disconnectRunner2.cancel();
-							onTerminate('renderer disconnected');
-						});
+						Event.once(protocol.onDidDispose)(() => onTerminate('renderer disconnected'));
 						resolve(protocol);
 
 						// Wait for rich client to reconnect
 						protocol.onSocketClose(() => {
 							// The socket has closed, let's give the renderer a certain amount of time to reconnect
-							if (!didDisconnect) {
-								disconnectRunner1.schedule();
-							}
+							disconnectRunner1.schedule();
 						});
 					}
 				}

--- a/src/vs/workbench/api/node/extensionHostProcess.ts
+++ b/src/vs/workbench/api/node/extensionHostProcess.ts
@@ -242,13 +242,21 @@ function _createExtHostProtocol(): Promise<IMessagePassingProtocol> {
 						clearTimeout(timer);
 						protocol = new PersistentProtocol({ socket, initialChunk: initialDataChunk });
 						protocol.sendResume();
-						Event.once(protocol.onDidDispose)(() => onTerminate('renderer disconnected'));
+						let didDisconnect = false;
+						Event.once(protocol.onDidDispose)(() => {
+							didDisconnect = true;
+							disconnectRunner1.cancel();
+							disconnectRunner2.cancel();
+							onTerminate('renderer disconnected');
+						});
 						resolve(protocol);
 
 						// Wait for rich client to reconnect
 						protocol.onSocketClose(() => {
 							// The socket has closed, let's give the renderer a certain amount of time to reconnect
-							disconnectRunner1.schedule();
+							if (!didDisconnect) {
+								disconnectRunner1.schedule();
+							}
 						});
 					}
 				}


### PR DESCRIPTION
Fixes a leak in 

### Details

When the connection closes, the extension host sends a disconnect message, and then closes the socket. The remote agent host, receives the disconnect message, starts its graceful cleanup but then the socket close event comes which immediately triggers `extHostSocket.destroy()` before the graceful cleanup is finished 


### Change

The change tries to ensure the `extHostSocket` gets shutdown gracefully, so that the cleanup code and still run and finish. 

### Before

When opening a new window and connecting it to SSH and then closing it 3 times, the number of processes seems to increase each time:

```json
{
  "processCount": {
    "after": 33,
    "before": 10
  },
  "isLeak": true
}
```


### After

When opening a new window and connecting it to SSH and then closing it 3 times, the number of processes seems to stay constant:

```json
{
  "processCount": {
    "after": 13,
    "before": 13
  },
  "isLeak": false
}
```