### PR TITLE
fix: memory leaks in chat widgets

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostModeSynchronizer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostModeSynchronizer.ts
@@ -42,6 +42,7 @@ export class AgentHostModeSynchronizer extends Disposable implements IWorkbenchC
 			this._attachWidget(widget);
 		}
 		this._register(this._chatWidgetService.onDidAddWidget(widget => this._attachWidget(widget)));
+		this._register(this._chatWidgetService.onDidRemoveWidget(widget => this._widgetListeners.deleteAndDispose(widget)));
 		this._register(this._chatWidgetService.onDidChangeFocusedSession(() => {
 			const widget = this._chatWidgetService.lastFocusedWidget;
 			if (widget) {

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -123,6 +123,7 @@ export interface IChatWidgetService {
 	readonly lastFocusedWidget: IChatWidget | undefined;
 
 	readonly onDidAddWidget: Event<IChatWidget>;
+	readonly onDidRemoveWidget: Event<IChatWidget>;
 
 	readonly onDidChangeWidgetVisibility: Event<IChatWidget>;
 

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { IObservable, observableValue, autorun, transaction, observableSignalFromEvent } from '../../../../../base/common/observable.js';
 import { disposableWindowInterval } from '../../../../../base/browser/dom.js';
 import { alert as ariaAlert } from '../../../../../base/browser/ui/aria/aria.js';
@@ -383,6 +383,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * second click, once the widget finally takes focus). Tracking the last-shown
 	 * session across all widgets closes that gap. */
 	private _lastShownSessionId: string | undefined;
+	private readonly _widgetSessionListeners = this._register(new DisposableMap<IChatWidget>());
 	/**
 	 * Agents-window active-session override. Beats focus/last-shown heuristics,
 	 * which are unreliable with multiple rendered chat widgets.
@@ -704,6 +705,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this._trackWidgetSession(widget);
 		}
 		this._register(this.chatWidgetService.onDidAddWidget(widget => this._trackWidgetSession(widget)));
+		this._register(this.chatWidgetService.onDidRemoveWidget(widget => this._widgetSessionListeners.deleteAndDispose(widget)));
 
 		// Set up the tool dispatch delegate — uses command bridge for widget ops
 		this.voiceToolDispatchService.setDelegate({
@@ -3243,7 +3245,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * chat view pane this way.
 	 */
 	private _trackWidgetSession(widget: IChatWidget): void {
-		this._register(widget.onDidChangeViewModel(e => this._onSessionShown(e.currentSessionResource)));
+		if (this._widgetSessionListeners.has(widget)) {
+			return;
+		}
+		this._widgetSessionListeners.set(widget, widget.onDidChangeViewModel(e => this._onSessionShown(e.currentSessionResource)));
 		// Seed from the widget's current view-model. When a session opens in a
 		// freshly-created widget, its view-model is often already set by the time
 		// we subscribe above, so the initial `onDidChangeViewModel` never fires

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
@@ -31,6 +31,9 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 	private readonly _onDidAddWidget = this._register(new Emitter<IChatWidget>());
 	readonly onDidAddWidget = this._onDidAddWidget.event;
 
+	private readonly _onDidRemoveWidget = this._register(new Emitter<IChatWidget>());
+	readonly onDidRemoveWidget = this._onDidRemoveWidget.event;
+
 	private readonly _onDidChangeWidgetVisibility = this._register(new Emitter<IChatWidget>());
 	readonly onDidChangeWidgetVisibility = this._onDidChangeWidgetVisibility.event;
 
@@ -277,6 +280,7 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 				if (this._lastFocusedWidget === newWidget) {
 					this.setLastFocusedWidget(undefined);
 				}
+				this._onDidRemoveWidget.fire(newWidget);
 			})
 		);
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostModeSynchronizer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostModeSynchronizer.test.ts
@@ -51,6 +51,7 @@ suite('AgentHostModeSynchronizer', () => {
 		let customModes = [...initialCustomModes];
 		const modeChanges = store.add(new Emitter<IChatModeChangeEvent>());
 		const modesChanges = store.add(new Emitter<void>());
+		const widgetRemovals = store.add(new Emitter<IChatWidget>());
 		const mode = observableValue<IChatMode>('mode', initialMode);
 		const modes = createModes(() => customModes, modesChanges.event);
 		const modesObservable = observableValue<IChatModes>('modes', modes);
@@ -76,6 +77,7 @@ suite('AgentHostModeSynchronizer', () => {
 		const widgetService = {
 			getAllWidgets: () => [widget],
 			onDidAddWidget: Event.None,
+			onDidRemoveWidget: widgetRemovals.event,
 			onDidChangeFocusedSession: Event.None,
 			getWidgetBySessionResource: (r: URI) => r.toString() === resource.toString() ? widget : undefined,
 			lastFocusedWidget: widget,
@@ -93,6 +95,8 @@ suite('AgentHostModeSynchronizer', () => {
 		return {
 			modeChanges,
 			modesChanges,
+			widget,
+			widgetRemovals,
 			setCustomModes: (next: readonly IChatMode[]) => {
 				customModes = [...next];
 			},
@@ -119,6 +123,27 @@ suite('AgentHostModeSynchronizer', () => {
 		await timeout(0);
 
 		assert.deepStrictEqual(setChatModeCalls, []);
+	});
+
+	test('stops observing a removed widget', async () => {
+		const untitledResource = URI.parse('agent-host-claude:/untitled-session-1');
+		const { modeChanges, modesChanges, setChatModeCalls, setCustomModes, storageService, widget, widgetRemovals } = createSynchronizer(ChatMode.Agent, [], untitledResource);
+		const key = agentHostAgentPickerStorageKey(untitledResource.scheme);
+		storageService.store(key, agentUri, StorageScope.PROFILE, StorageTarget.MACHINE);
+
+		widgetRemovals.fire(widget);
+		setCustomModes([createCustomMode()]);
+		modesChanges.fire();
+		modeChanges.fire({ isUserInitiated: true });
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			selectedAgent: storageService.get(key, StorageScope.PROFILE),
+			setChatModeCalls,
+		}, {
+			selectedAgent: agentUri,
+			setChatModeCalls: [],
+		});
 	});
 
 	test('retries restore when custom modes load late', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
@@ -26,7 +26,7 @@ import { workbenchInstantiationService } from '../../../../../test/browser/workb
 import { IVoiceTranscriptStore, IVoiceTranscriptTurn } from '../../../../agentsVoice/common/voiceTranscriptStore.js';
 import { IAgentSessionsModel } from '../../../browser/agentSessions/agentSessionsModel.js';
 import { IAgentSessionsService } from '../../../browser/agentSessions/agentSessionsService.js';
-import { IChatWidgetService } from '../../../browser/chat.js';
+import { IChatWidget, IChatWidgetService, IChatWidgetViewModelChangeEvent } from '../../../browser/chat.js';
 import { IMicCaptureService } from '../../../browser/voiceClient/micCaptureService.js';
 import { ITtsPlaybackService } from '../../../browser/voiceClient/ttsPlaybackService.js';
 import { IVoiceSessionController, VoiceSessionController } from '../../../browser/voiceClient/voiceSessionController.js';
@@ -247,6 +247,7 @@ function pendingConfirmationModel(resource: URI): IChatModel {
 class TestChatWidgetService extends mock<IChatWidgetService>() {
 	override readonly onDidChangeFocusedSession = Event.None;
 	override readonly onDidAddWidget = Event.None;
+	override readonly onDidRemoveWidget = Event.None;
 	override getAllWidgets() { return []; }
 }
 
@@ -295,6 +296,7 @@ suite('VoiceSessionController', () => {
 		micCaptureService: IMicCaptureService = new TestMicCaptureService(),
 		configurationService: IConfigurationService = new TestConfigurationService({ 'agents.voice.handsFree': false }),
 		chatService: IChatService = new TestChatService(),
+		chatWidgetService: IChatWidgetService = new TestChatWidgetService(),
 	): IVoiceSessionController {
 		store.add({ dispose: () => voiceClientService.dispose() });
 		store.add(ttsPlaybackService);
@@ -326,10 +328,38 @@ suite('VoiceSessionController', () => {
 				override async playSignal(): Promise<void> { }
 			}(),
 			new TestAccessibilityService(),
-			new TestChatWidgetService(),
+			chatWidgetService,
 			new class extends mock<INotificationService>() { }(),
 		));
 	}
+
+	test('stops tracking a removed chat widget', () => {
+		const voiceClientService = new TestVoiceClientService();
+		const viewModelChanges = store.add(new Emitter<IChatWidgetViewModelChangeEvent>());
+		const widgetRemovals = store.add(new Emitter<IChatWidget>());
+		const widget = {
+			viewModel: undefined,
+			onDidChangeViewModel: viewModelChanges.event,
+		} as unknown as IChatWidget;
+		const chatWidgetService = {
+			lastFocusedWidget: undefined,
+			onDidAddWidget: Event.None,
+			onDidRemoveWidget: widgetRemovals.event,
+			onDidChangeFocusedSession: Event.None,
+			getAllWidgets: () => [widget],
+		} as unknown as IChatWidgetService;
+		const controller = createController(voiceClientService, undefined, undefined, undefined, undefined, undefined, undefined, chatWidgetService);
+		const sessionResource = URI.parse('agent-host-copilot:/session-1');
+
+		viewModelChanges.fire({ previousSessionResource: undefined, currentSessionResource: sessionResource });
+		assert.strictEqual(Reflect.get(controller, '_lastShownSessionId'), sessionResource.toString());
+
+		widgetRemovals.fire(widget);
+		Reflect.set(controller, '_lastShownSessionId', undefined);
+		viewModelChanges.fire({ previousSessionResource: undefined, currentSessionResource: sessionResource });
+
+		assert.strictEqual(Reflect.get(controller, '_lastShownSessionId'), undefined);
+	});
 
 	test('explicit disconnect clears routing target and pending confirmations and the tracker cannot repopulate them before reconnect', () => {
 		const voiceClientService = new TestVoiceClientService();
@@ -1009,6 +1039,7 @@ suite('VoiceSessionController live transcription', () => {
 		instantiationService.stub(IChatWidgetService, {
 			lastFocusedWidget: undefined,
 			onDidAddWidget: Event.None,
+			onDidRemoveWidget: Event.None,
 			onDidChangeFocusedSession: Event.None,
 			getAllWidgets: () => [],
 		});

--- a/src/vs/workbench/contrib/chat/test/browser/widget/mockChatWidget.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/mockChatWidget.ts
@@ -11,6 +11,7 @@ import { ChatAgentLocation } from '../../../common/constants.js';
 
 export class MockChatWidgetService implements IChatWidgetService {
 	readonly onDidAddWidget: Event<IChatWidget> = Event.None;
+	readonly onDidRemoveWidget: Event<IChatWidget> = Event.None;
 	readonly onDidChangeWidgetVisibility: Event<IChatWidget> = Event.None;
 	readonly onDidBackgroundSession: Event<URI> = Event.None;
 	readonly onDidChangeFocusedWidget: Event<IChatWidget | undefined> = Event.None;

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -2148,6 +2148,7 @@ export class TestChatWidgetService implements IChatWidgetService {
 	lastFocusedWidget: IChatWidget | undefined;
 
 	onDidAddWidget = Event.None;
+	onDidRemoveWidget = Event.None;
 	onDidChangeWidgetVisibility = Event.None;
 	onDidBackgroundSession = Event.None;
 	onDidChangeFocusedWidget = Event.None;


### PR DESCRIPTION
### Details

When a chat editor is opened, services like `voiceSessionController` add event listeners to the chat widgets. But it seems those event listeners are not removed when the chat widget or chat editor closes. 

### Change

The change ensures that chat widgets event listeners like in `voiceSessionController` or ‎`agentHostModeSynchronizer` are being removed when the chat widget gets disposed. 

### Before

When opening two chat editors then closing all editors 37 times, the number of various functions seems to grow each time:


<img width="1400" height="4560" alt="chat-editor-open-side-by-side" src="https://github.com/user-attachments/assets/adc6c7a2-0fd7-4641-a191-d7f7db7dc77a" />


### After

When opening two chat editors then closing all editors 37 times, all but one function count stay constant:

<img width="1400" height="20" alt="chat-editor-open-side-by-side2" src="https://github.com/user-attachments/assets/d8c6ded6-8de8-4c33-83f4-5b8d66a3d112" />

### Test Video

https://github.com/user-attachments/assets/bd9a527d-2755-4c58-9d4b-dddb79b12218



