### PR TITLE
fix: memory leak in decorationAddon._decorations

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -311,7 +311,13 @@ export class DecorationAddon extends Disposable implements ITerminalAddon, IDeco
 				return;
 			}
 			if (!this._decorations.get(decoration.marker.id)) {
-				decoration.onDispose(() => this._decorations.delete(decoration.marker.id));
+				decoration.onDispose(() => {
+					const disposableDecoration = this._decorations.get(decoration.marker.id);
+					if (disposableDecoration) {
+						dispose(disposableDecoration.disposables);
+						this._decorations.delete(decoration.marker.id);
+					}
+				});
 				this._decorations.set(decoration.marker.id,
 					{
 						decoration,


### PR DESCRIPTION
### Details

Disposes terminal decoration hover and context menu resources with their marker.

### Before

When running the same task 37 times, terminal decoration callbacks grow each time (outlined in red):

<img width="1400" height="220" alt="task-run-fix-terminal-decoration-marker-memory-leak-before" src="https://github.com/user-attachments/assets/76779768-4648-45c1-9a18-f132e4e559c6" />

### After

No more leak is detected for these callbacks.

<img width="1400" height="80" alt="task-run-fix-terminal-decoration-marker-memory-leak-after" src="https://github.com/user-attachments/assets/0e526288-8c22-4a98-84a4-5af8e74e5260" />