### PR TITLE
fix: memory leak in commandDetectionCapability

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/capabilities.ts
+++ b/src/vs/platform/terminal/common/capabilities/capabilities.ts
@@ -295,6 +295,7 @@ export interface IPartialCommandDetectionCapability {
 	readonly type: TerminalCapability.PartialCommandDetection;
 	readonly commands: readonly IMarker[];
 	readonly onCommandFinished: Event<IMarker>;
+	clearCommandsInViewport(): void;
 }
 
 interface IBaseTerminalCommand {

--- a/src/vs/platform/terminal/common/capabilities/capabilities.ts
+++ b/src/vs/platform/terminal/common/capabilities/capabilities.ts
@@ -239,6 +239,7 @@ export interface ICommandDetectionCapability {
 	 */
 	getCwdForLine(line: number): string | undefined;
 	getCommandForLine(line: number): ITerminalCommand | ICurrentPartialCommand | undefined;
+	clearCommandsInViewport(): void;
 	handlePromptStart(options?: IHandleCommandOptions): void;
 	handleContinuationStart(): void;
 	handleContinuationEnd(): void;

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -202,6 +202,10 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		}
 	}
 
+	clearCommandsInViewport(): void {
+		this._clearCommandsInViewport();
+	}
+
 	setContinuationPrompt(value: string): void {
 		this._promptInputModel.setContinuationPrompt(value);
 	}

--- a/src/vs/platform/terminal/common/capabilities/partialCommandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/partialCommandDetectionCapability.ts
@@ -37,7 +37,7 @@ export class PartialCommandDetectionCapability extends DisposableStore implement
 		this.add(this._terminal.onData(e => this._onData(e)));
 		this.add(this._terminal.parser.registerCsiHandler({ final: 'J' }, params => {
 			if (params.length >= 1 && (params[0] === 2 || params[0] === 3)) {
-				this._clearCommandsInViewport();
+				this.clearCommandsInViewport();
 			}
 			// We don't want to override xterm.js' default behavior, just augment it
 			return false;
@@ -66,7 +66,7 @@ export class PartialCommandDetectionCapability extends DisposableStore implement
 		}
 	}
 
-	private _clearCommandsInViewport(): void {
+	clearCommandsInViewport(): void {
 		// Find the number of commands on the tail end of the array that are within the viewport
 		let count = 0;
 		for (let i = this._commands.length - 1; i >= 0; i--) {

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -774,6 +774,7 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 
 	clearBuffer(): void {
 		this._capabilities.get(TerminalCapability.CommandDetection)?.clearCommandsInViewport();
+		this._capabilities.get(TerminalCapability.PartialCommandDetection)?.clearCommandsInViewport();
 		this.raw.clear();
 		// xterm.js does not clear the first prompt, so trigger these to simulate
 		// the prompt being written

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -773,6 +773,7 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 	}
 
 	clearBuffer(): void {
+		this._capabilities.get(TerminalCapability.CommandDetection)?.clearCommandsInViewport();
 		this.raw.clear();
 		// xterm.js does not clear the first prompt, so trigger these to simulate
 		// the prompt being written

--- a/src/vs/workbench/contrib/terminal/test/browser/capabilities/partialCommandDetectionCapability.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/capabilities/partialCommandDetectionCapability.test.ts
@@ -65,4 +65,18 @@ suite('PartialCommandDetectionCapability', () => {
 		onDidExecuteTextEmitter.fire();
 		deepEqual(addEvents.length, 2);
 	});
+
+	test('should clear commands in the viewport', async () => {
+		await writeP(xterm, 'ab');
+		xterm.input('\x0d');
+		await writeP(xterm, '\r\n\r\n');
+		await writeP(xterm, 'cd');
+		xterm.input('\x0d');
+		await writeP(xterm, '\r\n');
+		deepStrictEqual(capability.commands.map(e => e.line), [0, 2]);
+
+		capability.clearCommandsInViewport();
+
+		deepStrictEqual(capability.commands, []);
+	});
 });


### PR DESCRIPTION
### Details

Clears rich and partial command detection history when the terminal buffer is cleared.

### Before

When running the same task and clearing the terminal 37 times, retained commands and their decorations grow each time (outlined in red):

<img width="1400" height="220" alt="task-run-fix-clear-terminal-command-history-before" src="https://github.com/user-attachments/assets/40fed90b-ff6c-4b1a-9137-a6ecce51f8e2" />

### After

No more retained command or partial-command marker growth is detected.

<img width="1400" height="80" alt="task-run-fix-clear-terminal-command-history-after" src="https://github.com/user-attachments/assets/697945e5-2816-4d9d-9abd-ac9b7d3a7916" />