### PR TITLE
fix: dispose terminal data listeners with instances

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/browser/mainThreadTerminalService.ts
@@ -475,6 +475,7 @@ export class MainThreadTerminalService extends Disposable implements MainThreadT
  */
 class TerminalDataEventTracker extends Disposable {
 	private readonly _bufferer: TerminalDataBufferer;
+	private readonly _instanceListeners = this._register(new DisposableMap<number>());
 
 	constructor(
 		private readonly _callback: (id: number, data: string) => void,
@@ -488,12 +489,15 @@ class TerminalDataEventTracker extends Disposable {
 			this._registerInstance(instance);
 		}
 		this._register(this._terminalService.onDidCreateInstance(instance => this._registerInstance(instance)));
-		this._register(this._terminalService.onDidDisposeInstance(instance => this._bufferer.stopBuffering(instance.instanceId)));
+		this._register(this._terminalService.onDidDisposeInstance(instance => {
+			this._bufferer.stopBuffering(instance.instanceId);
+			this._instanceListeners.deleteAndDispose(instance.instanceId);
+		}));
 	}
 
 	private _registerInstance(instance: ITerminalInstance): void {
 		// Buffer data events to reduce the amount of messages going to the extension host
-		this._register(this._bufferer.startBuffering(instance.instanceId, instance.onData));
+		this._instanceListeners.set(instance.instanceId, this._bufferer.startBuffering(instance.instanceId, instance.onData));
 	}
 }
 


### PR DESCRIPTION
### Details

Tracks each terminal instance's buffered data listener in a `DisposableMap` and disposes it when that terminal instance is disposed.

### Root cause

`TerminalDataEventTracker` stopped buffering for a disposed terminal, but the `instance.onData` subscription returned by `TerminalDataBufferer.startBuffering` stayed registered for the lifetime of the tracker. Repeated hidden terminal creation therefore retained one callback per run.

### Before

After running `chat-editor-execute-terminal-command` 37 times, the terminal data buffering callback grows by 37:

<img width="1400" alt="terminal-data-listeners-before" src="https://github.com/user-attachments/assets/eebfcf73-c837-43c6-8b12-0b144fe3dd08" />

### After

The matching retained row is gone on this isolated branch:

<img width="1400" alt="terminal-data-listeners-after" src="https://github.com/user-attachments/assets/274f67d1-a622-42fa-aaa9-2bf436be5776" />

### Test video

Seven runs on this branch with the proxy mock:

https://github.com/user-attachments/assets/11ad4f97-293a-4f87-afa6-045dce37f0a3

### Validation

- `npm run typecheck-client`
- `npm run transpile-client`
- `ELECTRON_DISABLE_SANDBOX=1 scripts/test.sh --grep 'Workbench - TerminalDataBufferer'` — 5 passing
- `chat-editor-execute-terminal-command` with `--runs 37 --measure named-function-count3 --check-leaks` — target row removed
- Recorded `chat-editor-execute-terminal-command` with `--runs 7`

Other independently rooted retained rows intentionally remain so this change can be reviewed on its own.
