### PR TITLE
fix: dispose background terminal listeners

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -8,7 +8,7 @@ import * as cssValue from '../../../../base/browser/cssValue.js';
 import { DeferredPromise, timeout, type MaybePromise } from '../../../../base/common/async.js';
 import { debounce, memoize } from '../../../../base/common/decorators.js';
 import { DynamicListEventMultiplexer, Emitter, Event, IDynamicListEventMultiplexer } from '../../../../base/common/event.js';
-import { Disposable, DisposableStore, dispose, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { isMacintosh, isWeb } from '../../../../base/common/platform.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -74,7 +74,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 
 	private _isShuttingDown: boolean = false;
 	private _backgroundedTerminalInstances: IBackgroundTerminal[] = [];
-	private _backgroundedTerminalDisposables: Map<number, IDisposable[]> = new Map();
+	private readonly _backgroundedTerminalDisposables = this._register(new DisposableMap<number>());
 	private _processSupportContextKey: IContextKey<boolean>;
 
 	private _primaryBackend?: ITerminalBackend;
@@ -1075,15 +1075,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 		if (shellLaunchConfig.hideFromUser) {
 			const instance = this._terminalInstanceService.createInstance(shellLaunchConfig, location);
 			this._backgroundedTerminalInstances.push({ instance, terminalLocationOptions: options?.location });
-			this._backgroundedTerminalDisposables.set(instance.instanceId, [
-				instance.onDisposed(instance => {
-					const idx = this._backgroundedTerminalInstances.findIndex(bg => bg.instance === instance);
-					if (idx !== -1) {
-						this._backgroundedTerminalInstances.splice(idx, 1);
-					}
-					this._onDidDisposeInstance.fire(instance);
-				})
-			]);
+			this._backgroundedTerminalDisposables.set(instance.instanceId, instance.onDisposed(instance => this._onBackgroundTerminalDisposed(instance)));
 			this._onDidChangeInstances.fire();
 			return instance;
 		}
@@ -1322,22 +1314,18 @@ export class TerminalService extends Disposable implements ITerminalService {
 
 		// Track in background
 		this._backgroundedTerminalInstances.push({ instance, terminalLocationOptions: instance.target === TerminalLocation.Editor ? { viewColumn: ACTIVE_GROUP } : undefined });
-		this._backgroundedTerminalDisposables.set(instance.instanceId, [
-			instance.onDisposed(instance => {
-				const idx = this._backgroundedTerminalInstances.findIndex(bg => bg.instance === instance);
-				if (idx !== -1) {
-					this._backgroundedTerminalInstances.splice(idx, 1);
-				}
-				const disposables = this._backgroundedTerminalDisposables.get(instance.instanceId);
-				if (disposables) {
-					dispose(disposables);
-				}
-				this._backgroundedTerminalDisposables.delete(instance.instanceId);
-				this._onDidDisposeInstance.fire(instance);
-			})
-		]);
+		this._backgroundedTerminalDisposables.set(instance.instanceId, instance.onDisposed(instance => this._onBackgroundTerminalDisposed(instance)));
 
 		this._onDidChangeInstances.fire();
+	}
+
+	private _onBackgroundTerminalDisposed(instance: ITerminalInstance): void {
+		const index = this._backgroundedTerminalInstances.findIndex(backgrounded => backgrounded.instance === instance);
+		if (index !== -1) {
+			this._backgroundedTerminalInstances.splice(index, 1);
+		}
+		this._backgroundedTerminalDisposables.deleteAndDispose(instance.instanceId);
+		this._onDidDisposeInstance.fire(instance);
 	}
 
 	public async showBackgroundTerminal(instance: ITerminalInstance, suppressSetActive?: boolean): Promise<void> {
@@ -1347,11 +1335,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 		}
 		const backgroundTerminal = this._backgroundedTerminalInstances[index];
 		this._backgroundedTerminalInstances.splice(index, 1);
-		const disposables = this._backgroundedTerminalDisposables.get(instance.instanceId);
-		if (disposables) {
-			dispose(disposables);
-		}
-		this._backgroundedTerminalDisposables.delete(instance.instanceId);
+		this._backgroundedTerminalDisposables.deleteAndDispose(instance.instanceId);
 		if (instance.target === TerminalLocation.Panel) {
 			this._terminalGroupService.createGroup(instance);
 


### PR DESCRIPTION
### Details

Uses a registered `DisposableMap` for background terminal subscriptions and routes both hidden-terminal and moved-to-background disposal through one cleanup path.

### Root cause

The `instance.onDisposed` subscription for terminals created with `hideFromUser` stayed in `_backgroundedTerminalDisposables` after the terminal was disposed. Repeated chat terminal commands therefore retained one `TerminalService.createTerminal` callback per run.

### Before

After running `chat-editor-execute-terminal-command` 37 times, the background terminal callback grows by 37:

<img width="1400" alt="background-terminal-listeners-before" src="https://github.com/user-attachments/assets/eadbd3e2-ac5e-4651-bc0d-d6c02a1b7270" />

### After

The matching retained row is gone on this isolated branch:

<img width="1400" alt="background-terminal-listeners-after" src="https://github.com/user-attachments/assets/aee09917-4d33-4cb0-a71e-4e88505f2294" />

### Test video

Seven runs on this branch with the proxy mock:

https://github.com/user-attachments/assets/11ad4f97-293a-4f87-afa6-045dce37f0a3

### Validation

- `npm run typecheck-client`
- `npm run transpile-client`
- `ELECTRON_DISABLE_SANDBOX=1 scripts/test.sh --grep 'Workbench - TerminalService'` — 7 passing
- `chat-editor-execute-terminal-command` with `--runs 37 --measure named-function-count3 --check-leaks` — target row removed
- Recorded `chat-editor-execute-terminal-command` with `--runs 7`

Other independently rooted retained rows intentionally remain so this change can be reviewed on its own.
