### PR TITLE
fix: dispose chat carousel listeners

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -24,7 +24,7 @@ import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Iterable } from '../../../../../../base/common/iterator.js';
 import { KeyCode } from '../../../../../../base/common/keyCodes.js';
 import { Lazy } from '../../../../../../base/common/lazy.js';
-import { Disposable, DisposableMap, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { combinedDisposable, Disposable, DisposableMap, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ResourceSet } from '../../../../../../base/common/map.js';
 import { MarshalledId } from '../../../../../../base/common/marshallingIds.js';
 import { Schemas } from '../../../../../../base/common/network.js';
@@ -307,6 +307,10 @@ const emptyInputAttachments = observableMemento<readonly IChatRequestVariableEnt
 	fromStorage: deserializeUntitledInputAttachments,
 });
 
+interface IChatToolConfirmationCarouselEntry extends IDisposable {
+	readonly part: ChatToolConfirmationCarouselPart;
+}
+
 export class ChatInputPart extends Disposable implements IHistoryNavigationWidget {
 	private static _counter = 0;
 
@@ -321,7 +325,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private readonly _chatPlanReviewWidgets = this._register(new DisposableMap<string, ChatPlanReviewPart>());
 	private readonly _planReviewResponseIds = new Map<string, string>();
 	private readonly _planReviewSessionResources = new Map<string, URI>();
-	private readonly _chatToolConfirmationCarousels = this._register(new DisposableMap<string, ChatToolConfirmationCarouselPart>());
+	private readonly _chatToolConfirmationCarousels = this._register(new DisposableMap<string, IChatToolConfirmationCarouselEntry>());
 	private readonly _chatEditingTodosDisposables = this._register(new DisposableStore());
 	private _lastEditingSessionResource: URI | undefined;
 
@@ -3934,7 +3938,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 	private get _currentToolConfirmationCarousel(): ChatToolConfirmationCarouselPart | undefined {
 		const key = this._currentSessionKey;
-		return key ? this._chatToolConfirmationCarousels.get(key) : undefined;
+		return key ? this._chatToolConfirmationCarousels.get(key)?.part : undefined;
 	}
 
 	renderToolConfirmationCarousel(tool: IChatToolInvocation, factory: ToolInvocationPartFactory, subAgentInvocationId?: string, agentName?: string, scrollToSubagent?: ScrollToSubagentCallback, toolPart?: ChatToolInvocationPart): ChatToolConfirmationCarouselPart {
@@ -3952,19 +3956,20 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		const part = new ChatToolConfirmationCarouselPart(factory, [], scrollToSubagent, subAgentInvocationId, agentName);
 		part.addToolInvocation(tool, subAgentInvocationId, agentName, scrollToSubagent, toolPart);
-		this._chatToolConfirmationCarousels.set(key, part);
 		dom.append(this.chatToolConfirmationCarouselContainer, part.domNode);
 		dom.show(this.chatToolConfirmationCarouselContainer);
 		this.updateToolConfirmationCarouselMaxHeight();
 
 		const capturedKey = key;
-		this._register(Event.once(part.onDidEmpty)(() => {
+		const emptyListener = Event.once(part.onDidEmpty)(() => {
 			this._chatToolConfirmationCarousels.deleteAndDispose(capturedKey);
 			if (this._currentSessionKey === capturedKey) {
 				dom.clearNode(this.chatToolConfirmationCarouselContainer);
 				dom.hide(this.chatToolConfirmationCarouselContainer);
 			}
-		}));
+		});
+		const disposable = combinedDisposable(part, emptyListener);
+		this._chatToolConfirmationCarousels.set(key, { part, dispose: () => disposable.dispose() });
 
 		return part;
 	}


### PR DESCRIPTION
### Details

Stores each tool-confirmation carousel together with its one-shot empty listener and disposes both when the carousel entry is removed.

### Root cause

The `onDidEmpty` listener was registered on `ChatInputPart` itself, so clearing a session's carousel disposed the carousel but left the listener registered until the entire input part was disposed. Repeated sessions retained one callback per run.

### Before

After running `chat-editor-execute-terminal-command` 37 times, the carousel callback grows by 37:

<img width="1400" alt="chat-carousel-listeners-before" src="https://github.com/user-attachments/assets/f8115134-1c3e-494b-aa63-a68014214008" />

### After

The matching retained row is gone on this isolated branch:

<img width="1400" alt="chat-carousel-listeners-after" src="https://github.com/user-attachments/assets/5b707998-ca80-4c81-ab51-2c6458e88dbe" />

### Test video

Seven runs on this branch with the proxy mock:

https://github.com/user-attachments/assets/11ad4f97-293a-4f87-afa6-045dce37f0a3

### Validation

- `npm run typecheck-client`
- `npm run transpile-client`
- `chat-editor-execute-terminal-command` with `--runs 37 --measure named-function-count3 --check-leaks` — target row removed
- Recorded `chat-editor-execute-terminal-command` with `--runs 7`

Other independently rooted retained rows intentionally remain so this change can be reviewed on its own.
