### PR TITLE
fix: dispose chat follow-up tokens

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -284,6 +284,7 @@ export class ChatService extends Disposable implements IChatService {
 		this._register(this._sessionModels.onDidDisposeModel(model => {
 			clearChatMarks(model.sessionResource);
 			this.chatDebugService.endSession(model.sessionResource);
+			this._sessionFollowupCancelTokens.deleteAndDispose(model.sessionResource);
 			// Drop the forward untitled→real mapping for this session so it stops
 			// re-targeting late sends. The inverse alias is intentionally retained.
 			this.chatSessionService.clearMaterializedSessionResource(model.sessionResource);


### PR DESCRIPTION
### Details

Disposes and removes a session's follow-up cancellation token when its chat model is disposed.

### Root cause

`_sessionFollowupCancelTokens` kept its `CancellationTokenSource` after the corresponding chat session model was removed. Each completed test session therefore retained its cancellation source, mutable token, and map entry.

### Before

After running `chat-editor-execute-terminal-command` 37 times, follow-up cancellation tokens grow with the repeated sessions:

<img width="1400" alt="chat-followup-tokens-before" src="https://github.com/user-attachments/assets/1239458c-bbe6-4e71-9fe4-93a8e58c59b2" />

### After

The matching `CancellationTokenSource` and `MutableToken` retained rows are gone on this isolated branch:

<img width="1400" alt="chat-followup-tokens-after" src="https://github.com/user-attachments/assets/4ca34ebd-8c90-43ef-b7e6-ed349ad6bef5" />

### Test video

Seven runs on this branch with the proxy mock:

https://github.com/user-attachments/assets/11ad4f97-293a-4f87-afa6-045dce37f0a3

### Validation

- `npm run typecheck-client`
- `npm run transpile-client`
- `chat-editor-execute-terminal-command` with `--runs 37 --measure named-function-count3 --check-leaks` — token rows removed
- Recorded `chat-editor-execute-terminal-command` with `--runs 7`

Other independently rooted retained rows intentionally remain so this change can be reviewed on its own.
