### PR TITLE
fix: clear state for removed agent sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -518,13 +518,32 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 		this._register(this.chatSessionsService.onDidChangeAvailability(() => this.resolve(undefined)));
 		this._register(this.chatSessionsService.onDidChangeSessionItems((delta) => {
 			const changedChatSessionTypes = new Set<string>();
+			const replacementsByLegacyResource = new Map<string, IChatSessionItem>();
 
 			for (const resource of delta.addedOrUpdated ?? []) {
 				changedChatSessionTypes.add(getChatSessionType(resource.resource));
+				if (resource.legacyResource) {
+					replacementsByLegacyResource.set(resource.legacyResource.toString(), resource);
+				}
 			}
 
+			let didRemoveSession = false;
 			for (const resource of delta.removed ?? []) {
 				changedChatSessionTypes.add(getChatSessionType(resource));
+				const replacement = replacementsByLegacyResource.get(resource.toString());
+				if (replacement) {
+					this.resolveStateEntry(replacement);
+				}
+				if (this._sessions.has(resource)) {
+					this._sessions.delete(resource);
+					didRemoveSession = true;
+				}
+				this.sessionStates.delete(resource);
+				this._sessionObservables.delete(resource);
+				this._resolvedResources.delete(resource);
+			}
+			if (didRemoveSession) {
+				this._onDidChangeSessions.fire();
 			}
 
 			for (const chatSessionType of changedChatSessionTypes) {
@@ -684,6 +703,19 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 		// Phase 2: Atomically update sessions (sync - reads latest this._sessions
 		// so concurrent updateItems calls for other providers don't lose data)
 
+		const removedResources: URI[] = [];
+		for (const [resource, session] of this._sessions) {
+			if (session.providerType === provider && !sessions.has(resource)) {
+				removedResources.push(resource);
+			}
+		}
+		const replacementsByLegacyResource = new Map<string, IInternalAgentSession>();
+		for (const session of sessions.values()) {
+			if (session.legacyResource) {
+				replacementsByLegacyResource.set(session.legacyResource.toString(), session);
+			}
+		}
+
 		for (const [, session] of this._sessions) {
 			if (
 				session.providerType !== provider &&
@@ -710,6 +742,17 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 		for (const session of sessionsWithChangedArchivedState) {
 			this._onDidChangeSessionArchivedState.fire(session);
 		}
+
+		for (const removedResource of removedResources) {
+			const replacement = replacementsByLegacyResource.get(removedResource.toString());
+			if (replacement) {
+				this.resolveStateEntry(replacement);
+			}
+			this.sessionStates.delete(removedResource);
+			this._sessionObservables.delete(removedResource);
+			this._resolvedResources.delete(removedResource);
+		}
+
 		this._onDidChangeSessions.fire();
 	}
 
@@ -739,7 +782,7 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 	 * the current resource key and removes the legacy entry). Returns undefined if
 	 * neither a current nor a legacy entry exists.
 	 */
-	private resolveStateEntry(session: IInternalAgentSessionData): IAgentSessionState | undefined {
+	private resolveStateEntry(session: Pick<IInternalAgentSessionData, 'resource' | 'legacyResource'>): IAgentSessionState | undefined {
 		const own = this.sessionStates.get(session.resource);
 		if (own !== undefined) {
 			return own;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
@@ -1431,6 +1431,25 @@ suite('AgentSessions', () => {
 			});
 		});
 
+		test('should discard local state for removed sessions', async () => {
+			return runWithFakedTimers({}, async () => {
+				const item = makeSimpleSessionItem('session-1');
+				mockChatSessionsService.registerChatSessionItemController(chatSessionTestType, new StaticChatSessionItemController([item]));
+				viewModel = disposables.add(instantiationService.createInstance(AgentSessionsModel));
+				await viewModel.resolve(undefined);
+				viewModel.sessions[0].setArchived(true);
+
+				mockChatSessionsService.registerChatSessionItemController(chatSessionTestType, new StaticChatSessionItemController([]));
+				mockChatSessionsService.fireDidChangeSessionItems({ removed: [item.resource] });
+				assert.strictEqual(viewModel.sessions.length, 0);
+
+				mockChatSessionsService.registerChatSessionItemController(chatSessionTestType, new StaticChatSessionItemController([item]));
+				await viewModel.resolve(undefined);
+
+				assert.strictEqual(viewModel.sessions[0].isArchived(), false);
+			});
+		});
+
 		test('should fire archive state changes only for effective provider transitions', async () => {
 			return runWithFakedTimers({}, async () => {
 				const item = makeSimpleSessionItem('session-1', { archived: false });


### PR DESCRIPTION
### Details

Removes cached state, observables, and resolved-resource entries when a provider removes an agent session. If a new session replaces a removed legacy resource, its state is migrated before the stale entry is deleted.

### Root cause

Provider refreshes replaced `_sessions`, but auxiliary maps retained entries for sessions no longer returned by that provider. Those entries kept `ResourceMapEntry` objects and the session state callbacks alive across repeated chat sessions.

### Before

After running `chat-editor-execute-terminal-command` 37 times, removed session state and callbacks grow with each session:

<img width="1400" alt="agent-session-state-before" src="https://github.com/user-attachments/assets/d53edfa4-0823-4840-a403-0efda7ca57b7" />

### After

The matching retained state and callback rows are gone on this isolated branch:

<img width="1400" alt="agent-session-state-after" src="https://github.com/user-attachments/assets/60188e88-5424-4e2f-8662-9c1a0f66b738" />

### Test video

Seven runs on this branch with the proxy mock:

https://github.com/user-attachments/assets/11ad4f97-293a-4f87-afa6-045dce37f0a3

### Validation

- `npm run typecheck-client`
- `npm run transpile-client`
- Agent session archiving tests — 9 passing
- Agent session `legacyResource` migration tests — 8 passing
- `chat-editor-execute-terminal-command` with `--runs 37 --measure named-function-count3 --check-leaks` — target rows removed
- Recorded `chat-editor-execute-terminal-command` with `--runs 7`

Other independently rooted retained rows intentionally remain so this change can be reviewed on its own.
