### PR TITLE
fix: memory leak in mainThreadTerminalService

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/browser/mainThreadTerminalService.ts
@@ -475,6 +475,7 @@ export class MainThreadTerminalService extends Disposable implements MainThreadT
  */
 class TerminalDataEventTracker extends Disposable {
 	private readonly _bufferer: TerminalDataBufferer;
+	private readonly _instanceListeners = this._register(new DisposableMap<number>());
 
 	constructor(
 		private readonly _callback: (id: number, data: string) => void,
@@ -488,12 +489,15 @@ class TerminalDataEventTracker extends Disposable {
 			this._registerInstance(instance);
 		}
 		this._register(this._terminalService.onDidCreateInstance(instance => this._registerInstance(instance)));
-		this._register(this._terminalService.onDidDisposeInstance(instance => this._bufferer.stopBuffering(instance.instanceId)));
+		this._register(this._terminalService.onDidDisposeInstance(instance => {
+			this._bufferer.stopBuffering(instance.instanceId);
+			this._instanceListeners.deleteAndDispose(instance.instanceId);
+		}));
 	}
 
 	private _registerInstance(instance: ITerminalInstance): void {
 		// Buffer data events to reduce the amount of messages going to the extension host
-		this._register(this._bufferer.startBuffering(instance.instanceId, instance.onData));
+		this._instanceListeners.set(instance.instanceId, this._bufferer.startBuffering(instance.instanceId, instance.onData));
 	}
 }
 


### PR DESCRIPTION
### Details

When terminal data buffering starts, `TerminalDataEventTracker` subscribes to each terminal instance's `onData` event. Stopping the buffer for a disposed terminal did not dispose that source subscription, so the callback stayed reachable.

### Change

The change stores each terminal instance's buffering subscription in a `DisposableMap` and removes and disposes it together with the terminal instance.

### Before

When executing a terminal command from chat 37 times, the terminal data buffering callback grows each time (outlined in red):

<img width="1400" alt="chat-editor-execute-terminal-command-mainThreadTerminalService-before" src="https://github.com/user-attachments/assets/c44bcd82-a986-474c-829a-93daba0aee2f" />

### After

No more leak is detected for this callback.

<img width="1400" alt="chat-editor-execute-terminal-command-mainThreadTerminalService-after" src="https://github.com/user-attachments/assets/7297e98d-01b5-4f7d-89b7-80781dfb72c2" />

### Test Video

https://github.com/user-attachments/assets/11ad4f97-293a-4f87-afa6-045dce37f0a3
