### PR TITLE
fix: memory leak in terminalService

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -8,7 +8,7 @@ import * as cssValue from '../../../../base/browser/cssValue.js';
 import { DeferredPromise, timeout, type MaybePromise } from '../../../../base/common/async.js';
 import { debounce, memoize } from '../../../../base/common/decorators.js';
 import { DynamicListEventMultiplexer, Emitter, Event, IDynamicListEventMultiplexer } from '../../../../base/common/event.js';
-import { Disposable, DisposableStore, dispose, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { isMacintosh, isWeb } from '../../../../base/common/platform.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -74,7 +74,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 
 	private _isShuttingDown: boolean = false;
 	private _backgroundedTerminalInstances: IBackgroundTerminal[] = [];
-	private _backgroundedTerminalDisposables: Map<number, IDisposable[]> = new Map();
+	private readonly _backgroundedTerminalDisposables = this._register(new DisposableMap<number>());
 	private _processSupportContextKey: IContextKey<boolean>;
 
 	private _primaryBackend?: ITerminalBackend;
@@ -1075,15 +1075,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 		if (shellLaunchConfig.hideFromUser) {
 			const instance = this._terminalInstanceService.createInstance(shellLaunchConfig, location);
 			this._backgroundedTerminalInstances.push({ instance, terminalLocationOptions: options?.location });
-			this._backgroundedTerminalDisposables.set(instance.instanceId, [
-				instance.onDisposed(instance => {
-					const idx = this._backgroundedTerminalInstances.findIndex(bg => bg.instance === instance);
-					if (idx !== -1) {
-						this._backgroundedTerminalInstances.splice(idx, 1);
-					}
-					this._onDidDisposeInstance.fire(instance);
-				})
-			]);
+			this._backgroundedTerminalDisposables.set(instance.instanceId, instance.onDisposed(instance => this._onBackgroundTerminalDisposed(instance)));
 			this._onDidChangeInstances.fire();
 			return instance;
 		}
@@ -1322,22 +1314,18 @@ export class TerminalService extends Disposable implements ITerminalService {
 
 		// Track in background
 		this._backgroundedTerminalInstances.push({ instance, terminalLocationOptions: instance.target === TerminalLocation.Editor ? { viewColumn: ACTIVE_GROUP } : undefined });
-		this._backgroundedTerminalDisposables.set(instance.instanceId, [
-			instance.onDisposed(instance => {
-				const idx = this._backgroundedTerminalInstances.findIndex(bg => bg.instance === instance);
-				if (idx !== -1) {
-					this._backgroundedTerminalInstances.splice(idx, 1);
-				}
-				const disposables = this._backgroundedTerminalDisposables.get(instance.instanceId);
-				if (disposables) {
-					dispose(disposables);
-				}
-				this._backgroundedTerminalDisposables.delete(instance.instanceId);
-				this._onDidDisposeInstance.fire(instance);
-			})
-		]);
+		this._backgroundedTerminalDisposables.set(instance.instanceId, instance.onDisposed(instance => this._onBackgroundTerminalDisposed(instance)));
 
 		this._onDidChangeInstances.fire();
+	}
+
+	private _onBackgroundTerminalDisposed(instance: ITerminalInstance): void {
+		const index = this._backgroundedTerminalInstances.findIndex(backgrounded => backgrounded.instance === instance);
+		if (index !== -1) {
+			this._backgroundedTerminalInstances.splice(index, 1);
+		}
+		this._backgroundedTerminalDisposables.deleteAndDispose(instance.instanceId);
+		this._onDidDisposeInstance.fire(instance);
 	}
 
 	public async showBackgroundTerminal(instance: ITerminalInstance, suppressSetActive?: boolean): Promise<void> {
@@ -1347,11 +1335,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 		}
 		const backgroundTerminal = this._backgroundedTerminalInstances[index];
 		this._backgroundedTerminalInstances.splice(index, 1);
-		const disposables = this._backgroundedTerminalDisposables.get(instance.instanceId);
-		if (disposables) {
-			dispose(disposables);
-		}
-		this._backgroundedTerminalDisposables.delete(instance.instanceId);
+		this._backgroundedTerminalDisposables.deleteAndDispose(instance.instanceId);
 		if (instance.target === TerminalLocation.Panel) {
 			this._terminalGroupService.createGroup(instance);
 


### PR DESCRIPTION
### Details

Hidden background terminals register an `onDisposed` listener. Those listeners were stored in a plain map, and the `hideFromUser` path did not remove them when the terminal was disposed.

### Change

The change stores background terminal listeners in a registered `DisposableMap` and uses one cleanup path to remove and dispose each listener when the terminal is disposed or shown.

### Before

When executing a terminal command from chat 37 times, the background terminal callback grows each time (outlined in red):

<img width="1400" alt="chat-editor-execute-terminal-command-terminalService-before" src="https://github.com/user-attachments/assets/f22740fb-d627-4e5a-b7d3-844754903997" />

### After

No more leak is detected for this callback.

<img width="1400" alt="chat-editor-execute-terminal-command-terminalService-after" src="https://github.com/user-attachments/assets/d6f25308-1ac1-45ed-afa5-e4520a575599" />

### Test Video

https://github.com/user-attachments/assets/11ad4f97-293a-4f87-afa6-045dce37f0a3
