### PR TITLE
fix: memory leak in chatServiceImpl

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -284,6 +284,7 @@ export class ChatService extends Disposable implements IChatService {
 		this._register(this._sessionModels.onDidDisposeModel(model => {
 			clearChatMarks(model.sessionResource);
 			this.chatDebugService.endSession(model.sessionResource);
+			this._sessionFollowupCancelTokens.deleteAndDispose(model.sessionResource);
 			// Drop the forward untitled→real mapping for this session so it stops
 			// re-targeting late sends. The inverse alias is intentionally retained.
 			this.chatSessionService.clearMaterializedSessionResource(model.sessionResource);


### PR DESCRIPTION
### Details

Chat follow-up providers create cancellation token sources stored in `_sessionFollowupCancelTokens`. Disposing a chat session model did not remove and dispose its token source.

### Change

The change removes and disposes the matching follow-up cancellation token source when the chat session model is disposed.

### Before

When executing a terminal command from chat 37 times, follow-up cancellation token sources and mutable tokens grow across the runs (outlined in red):

<img width="1400" alt="chat-editor-execute-terminal-command-chatServiceImpl-before" src="https://github.com/user-attachments/assets/5b643501-f95f-47d6-b5a5-fb296dd5269e" />

### After

No more matching cancellation token leak is detected.

<img width="1400" alt="chat-editor-execute-terminal-command-chatServiceImpl-after" src="https://github.com/user-attachments/assets/dc73a304-7c01-48c7-afce-44e69a871fad" />

### Test Video

https://github.com/user-attachments/assets/11ad4f97-293a-4f87-afa6-045dce37f0a3
