### PR TITLE
fix: memory leak in historyService

### DIFF
--- a/src/vs/workbench/services/history/browser/historyService.ts
+++ b/src/vs/workbench/services/history/browser/historyService.ts
@@ -2181,7 +2181,10 @@ class EditorHelper {
 	}
 
 	onEditorDispose(editor: EditorInput, listener: Function, mapEditorToDispose: DisposableMap<EditorInput, DisposableStore>): void {
-		const toDispose = Event.once(editor.onWillDispose)(() => listener());
+		const toDispose = Event.once(editor.onWillDispose)(() => {
+			mapEditorToDispose.deleteAndDispose(editor);
+			listener();
+		});
 
 		let disposables = mapEditorToDispose.get(editor);
 		if (!disposables) {

--- a/src/vs/workbench/services/history/test/browser/historyService.test.ts
+++ b/src/vs/workbench/services/history/test/browser/historyService.test.ts
@@ -745,6 +745,30 @@ suite('HistoryService', function () {
 		return workbenchTeardown(instantiationService);
 	});
 
+	test('getHistory clears editor dispose listeners', async () => {
+
+		class TestFileEditorInputWithUntyped extends TestFileEditorInput {
+
+			override toUntyped(): IUntypedEditorInput {
+				return { resource: this.resource };
+			}
+		}
+
+		const [part, historyService, , , instantiationService] = await createServices();
+		historyService.getHistory();
+
+		const input = new TestFileEditorInputWithUntyped(URI.file('history-listener'), TEST_EDITOR_INPUT_ID);
+		await part.activeGroup.openEditor(input, { pinned: true });
+
+		const editorHistoryListeners = (historyService as unknown as { editorHistoryListeners: { size: number } }).editorHistoryListeners;
+		assert.strictEqual(editorHistoryListeners.size, 1);
+
+		input.dispose();
+		assert.strictEqual(editorHistoryListeners.size, 0);
+
+		return workbenchTeardown(instantiationService);
+	});
+
 	test('getLastActiveFile', async () => {
 		const [part, historyService] = await createServices();
 


### PR DESCRIPTION
### Details

HistoryService kept disposal callbacks for editor inputs in `editorHistoryListeners` after they ran. Disposed custom editor inputs therefore stayed reachable and retained their custom editor models and overlay webviews.

### Change

Delete and dispose the listener-map entry when the editor's `onWillDispose` event fires, before running the history callback.

### Before

When running `debug-javascript-performance-profile` 37 times, custom editor models, overlay webviews, and their retaining callbacks grow (outlined in red):

<img width="1400" height="100" alt="historyService-before" src="https://github.com/user-attachments/assets/fde918f5-58a9-47a3-ae6f-b3c5ea155b4b" />

### After

No more custom editor model, overlay webview, or retaining callback growth is detected.

<img width="1400" height="20" alt="historyService-after" src="https://github.com/user-attachments/assets/5df1863e-8a3b-401d-92d3-25c5c40cc461" />

### Test Video

[historyService-test-video.webm](https://github.com/user-attachments/assets/a9e60d3b-85eb-46f9-a924-ac6cf4634ea9)
