### PR TITLE
fix: memory leak in titleBarPart

### DIFF
--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -387,7 +387,7 @@ export class ActivityBarCompositeBar extends PaneCompositeBar {
 		content.prepend(this.menuBarContainer);
 
 		// Menubar: install a custom menu bar depending on configuration
-		this.menuBar.value = this._register(this.instantiationService.createInstance(CustomMenubarControl));
+		this.menuBar.value = this.instantiationService.createInstance(CustomMenubarControl);
 		this.menuBar.value.create(this.menuBarContainer);
 
 	}

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -266,6 +266,7 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 	private rightContent!: HTMLElement;
 
 	protected readonly customMenubar = this._register(new MutableDisposable<CustomMenubarControl>());
+	private readonly customMenubarDisposables = this._register(new DisposableStore());
 	protected appIcon: HTMLElement | undefined;
 	private appIconBadge: HTMLElement | undefined;
 	protected menubar?: HTMLElement;
@@ -429,18 +430,20 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 			return; // If the menubar is already installed, skip
 		}
 
-		this.customMenubar.value = this.instantiationService.createInstance(CustomMenubarControl);
+		const customMenubar = this.instantiationService.createInstance(CustomMenubarControl);
+		this.customMenubar.value = customMenubar;
 
 		this.menubar = append(this.leftContent, $('div.menubar'));
 		this.menubar.setAttribute('role', 'menubar');
 
-		this._register(this.customMenubar.value.onVisibilityChange(e => this.onMenubarVisibilityChanged(e)));
+		this.customMenubarDisposables.add(customMenubar.onVisibilityChange(e => this.onMenubarVisibilityChanged(e)));
 
-		this.customMenubar.value.create(this.menubar);
+		customMenubar.create(this.menubar);
 	}
 
 	private uninstallMenubar(): void {
-		this.customMenubar.value = undefined;
+		this.customMenubarDisposables.clear();
+		this.customMenubar.clear();
 
 		this.menubar?.remove();
 		this.menubar = undefined;


### PR DESCRIPTION
### Details

Each time the menu bar was hidden and shown, VS Code created a new `CustomMenubarControl`. The previous control's visibility listener was kept for the lifetime of the title bar, which also kept that control and its menu actions in memory.

### Change

When removing a menu bar, clear its visibility listener and `CustomMenubarControl` together. The activity bar now uses its existing `MutableDisposable` as the sole owner, so replacing a control releases the previous instance.

### Before

Before the change, toggling the menu bar 37 times left menu bar controls and their actions in memory, with counts growing after every toggle:

<img width="1400" height="440" alt="before" src="https://github.com/user-attachments/assets/bbd7b3cc-9afb-4805-9511-b345114e1182" />

### After

After the change, repeating the same 37 toggles reports no matching menu bar leak.

### Test Video

[test-video.webm](https://github.com/user-attachments/assets/a121bcde-7037-43bd-baf1-f0b99d620996)