### PR TITLE
feature: reduce number of strings by 1200

### DIFF
--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -1267,7 +1267,7 @@ export class Emitter<T> {
 
 			let removeMonitor: Function | undefined;
 			let stack: Stacktrace | undefined;
-			if (this._leakageMon && this._size >= Math.ceil(this._leakageMon.threshold * 0.2)) {
+			if (this._leakageMon && this._size + 1 >= this._leakageMon.threshold) {
 				// check and record this emitter for potential leakage
 				contained.stack = Stacktrace.create();
 				removeMonitor = this._leakageMon.check(contained.stack, this._size + 1);

--- a/src/vs/base/test/common/event.test.ts
+++ b/src/vs/base/test/common/event.test.ts
@@ -415,6 +415,47 @@ suite('Event', function () {
 		store.dispose();
 	});
 
+	test('does not capture listener stacks below the leak warning threshold', () => {
+		const control = ds.add(new Emitter<undefined>());
+		const monitored = ds.add(new Emitter<undefined>({
+			onListenerError() { },
+			leakWarningThreshold: 5,
+		}));
+		const originalError = globalThis.Error;
+		const warn = stub(console, 'warn');
+		let errorCount = 0;
+		globalThis.Error = new Proxy(originalError, {
+			construct(target, argumentsList, newTarget) {
+				errorCount++;
+				return Reflect.construct(target, argumentsList, newTarget);
+			},
+		});
+
+		try {
+			for (let i = 0; i < 4; i++) {
+				ds.add(control.event(() => { }));
+			}
+			const controlErrorCount = errorCount;
+
+			errorCount = 0;
+			for (let i = 0; i < 4; i++) {
+				ds.add(monitored.event(() => { }));
+			}
+			assert.strictEqual(errorCount, controlErrorCount);
+
+			errorCount = 0;
+			ds.add(control.event(() => { }));
+			const controlNextListenerErrorCount = errorCount;
+
+			errorCount = 0;
+			ds.add(monitored.event(() => { }));
+			assert.strictEqual(errorCount, controlNextListenerErrorCount + 1);
+		} finally {
+			globalThis.Error = originalError;
+			warn.restore();
+		}
+	});
+
 	test('reusing event function and context', function () {
 		let counter = 0;
 		function listener() {


### PR DESCRIPTION
### Details

Listener leak monitoring started capturing stack traces at 20% of its warning threshold:

```ts
if (this._leakageMon && this._size >= Math.ceil(this._leakageMon.threshold * 0.2)) {
	contained.stack = Stacktrace.create();
	removeMonitor = this._leakageMon.check(contained.stack, this._size + 1);
}
```

However, `LeakageMonitor.check()` ignores every call below the full threshold:

```ts
const threshold = this.threshold;
if (threshold <= 0 || listenerCount < threshold) {
	return undefined;
}

if (!this._stacks) {
	this._stacks = new Map();
}
```

With the workbench threshold of 175, listeners 36 through 174 therefore retained unused stack strings such as:

```text
Error
    at Stacktrace.create (.../vs/base/common/event.js:614:17)
    at ContextKeyService._event (.../vs/base/common/event.js:714:38)
    at ScopedContextKeyService._updateParentChangeListener (.../contextKeyService.js:384:53)
```

<br>

The graph shows ca. 1200 less error strings with this change:

![Concatenated Error String Count](https://github.com/user-attachments/assets/5da72c53-28d8-42f7-ab37-aa0e09955ea5)


Other measurements\*
- Memory: Estimated reduction: 52,268 bytes (~51 KiB)
- Startup performance −2.34 ms improvement, or −0.46%

\**average of 17 runs, might not be 100% accurate*