### PR TITLE
fix: memory leak in notebook view model

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl.ts
@@ -225,7 +225,7 @@ export class NotebookViewModel extends Disposable implements EditorFoldingStateD
 				deletedCells.forEach(cell => {
 					this._handleToViewCellMapping.delete(cell.handle);
 					// dispose the cell to release ref to the cell text document
-					cell.dispose();
+					this._localStore.delete(cell);
 				});
 
 				diff[2].forEach(cell => {

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookViewModel.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookViewModel.test.ts
@@ -104,6 +104,32 @@ suite('NotebookViewModel', () => {
 		);
 	});
 
+	test('deleted cells are removed from the disposable store', async function () {
+		const getDisposeCallCount = await withTestNotebook(
+			[
+				['var a = 1;', 'javascript', CellKind.Code, [], {}],
+				['var b = 2;', 'javascript', CellKind.Code, [], {}]
+			],
+			(editor, viewModel) => {
+				const cell = insertCellAtIndex(viewModel, 1, 'var c = 3', 'javascript', CellKind.Code, {}, [], true, true);
+				const originalDispose = cell.dispose.bind(cell);
+				let disposeCallCount = 0;
+				cell.dispose = () => {
+					disposeCallCount++;
+					originalDispose();
+				};
+
+				runDeleteAction(editor, cell);
+				assert.strictEqual(disposeCallCount, 1);
+				cell.model.dispose();
+
+				return () => disposeCallCount;
+			}
+		);
+
+		assert.strictEqual(getDisposeCallCount(), 1);
+	});
+
 	test('index', async function () {
 		await withTestNotebook(
 			[


### PR DESCRIPTION
### Details

Deleted notebook cell view models stayed reachable through `NotebookViewModel`'s disposable store after their cells were removed.

### Change

Remove deleted cell view models from the disposable store, which also disposes them immediately.

### Before

When splitting and joining a notebook cell 37 times, `CodeCellViewModel` grows once per iteration:

<img width="1400" height="400" alt="before" src="https://github.com/user-attachments/assets/ac46ebc8-4d30-46c7-af34-fb46cbe5f8c4" />


### After

No more `CodeCellViewModel` leak is detected.

<img width="1400" height="360" alt="after" src="https://github.com/user-attachments/assets/97839e3a-7a99-40ef-9df4-266d081551ec" />


### Test Video

[notebook-cell-split.webm](https://github.com/user-attachments/assets/6e44f51e-49a9-4024-8cd5-ec9874afd227)
