### PR TITLE
fix: memory leak in run and debug view

### DIFF
--- a/src/vs/workbench/browser/parts/compositePart.ts
+++ b/src/vs/workbench/browser/parts/compositePart.ts
@@ -186,27 +186,26 @@ export abstract class CompositePart<T extends Composite, MementoType extends obj
 		// Instantiate composite from registry otherwise
 		const compositeDescriptor = this.registry.getComposite(id);
 		if (compositeDescriptor) {
+			const disposable = new DisposableStore();
 			const that = this;
-			const compositeProgressIndicator = new ScopedProgressIndicator(assertReturnsDefined(this.progressBar), this._register(new class extends AbstractProgressScope {
+			const compositeProgressIndicator = disposable.add(new ScopedProgressIndicator(assertReturnsDefined(this.progressBar), disposable.add(new class extends AbstractProgressScope {
 				constructor() {
 					super(compositeDescriptor!.id, !!isActive);
 					this._register(that.onDidCompositeOpen.event(e => this.onScopeOpened(e.composite.getId())));
 					this._register(that.onDidCompositeClose.event(e => this.onScopeClosed(e.getId())));
 				}
-			}()));
-			const compositeInstantiationService = this._register(this.instantiationService.createChild(new ServiceCollection(
+			})));
+			const compositeInstantiationService = disposable.add(this.instantiationService.createChild(new ServiceCollection(
 				[IEditorProgressService, compositeProgressIndicator] // provide the editor progress service for any editors instantiated within the composite
 			)));
 
 			const composite = compositeDescriptor.instantiate(compositeInstantiationService);
-			const disposable = new DisposableStore();
 
 			// Remember as Instantiated
 			this.instantiatedCompositeItems.set(id, { composite, disposable, progress: compositeProgressIndicator });
 
 			// Register to title area update events from the composite
 			disposable.add(composite.onTitleAreaUpdate(() => this.onTitleAreaUpdate(composite.getId()), this));
-			disposable.add(compositeInstantiationService);
 
 			return composite;
 		}

--- a/src/vs/workbench/test/browser/parts/compositePart.test.ts
+++ b/src/vs/workbench/test/browser/parts/compositePart.test.ts
@@ -1,0 +1,152 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Dimension } from '../../../../base/browser/dom.js';
+import { IBoundarySashes } from '../../../../base/browser/ui/sash/sash.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
+import { IConstructorSignature, IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
+import { TestInstantiationService } from '../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { MockKeybindingService } from '../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { TestNotificationService } from '../../../../platform/notification/test/common/testNotificationService.js';
+import { IStorageService } from '../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../platform/telemetry/common/telemetryUtils.js';
+import { IThemeService } from '../../../../platform/theme/common/themeService.js';
+import { TestThemeService } from '../../../../platform/theme/test/common/testThemeService.js';
+import { Composite, CompositeDescriptor, CompositeRegistry } from '../../../browser/composite.js';
+import { CompositePart } from '../../../browser/parts/compositePart.js';
+import { NullHoverService } from '../../../../platform/hover/test/browser/nullHoverService.js';
+import { TestStorageService } from '../../common/workbenchTestServices.js';
+import { TestLayoutService } from '../workbenchTestServices.js';
+
+class TestComposite extends Composite {
+
+	static readonly ID = 'testComposite';
+
+	constructor(
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IThemeService themeService: IThemeService,
+		@IStorageService storageService: IStorageService,
+	) {
+		super(TestComposite.ID, telemetryService, themeService, storageService);
+	}
+
+	layout(_dimension: Dimension): void { }
+	setBoundarySashes(_sashes: IBoundarySashes): void { }
+}
+
+class TestCompositeDescriptor extends CompositeDescriptor<TestComposite> {
+
+	constructor() {
+		super(TestComposite as IConstructorSignature<TestComposite>, TestComposite.ID, 'Test Composite');
+	}
+}
+
+class TestCompositeRegistry extends CompositeRegistry<TestComposite> {
+
+	register(descriptor: CompositeDescriptor<TestComposite>): void {
+		this.registerComposite(descriptor);
+	}
+}
+
+class TestCompositePart extends CompositePart<TestComposite> {
+
+	readonly minimumWidth = 0;
+	readonly maximumWidth = Number.POSITIVE_INFINITY;
+	readonly minimumHeight = 0;
+	readonly maximumHeight = Number.POSITIVE_INFINITY;
+
+	constructor(
+		instantiationService: IInstantiationService,
+		registry: CompositeRegistry<TestComposite>,
+		storageService: IStorageService,
+		themeService: IThemeService,
+		layoutService: TestLayoutService,
+	) {
+		super(
+			new TestNotificationService(),
+			storageService,
+			{} as IContextMenuService,
+			layoutService,
+			new MockKeybindingService(),
+			NullHoverService,
+			instantiationService,
+			themeService,
+			registry,
+			'test.activeComposite',
+			TestComposite.ID,
+			'test',
+			'test-composite',
+			undefined,
+			undefined,
+			'testCompositePart',
+			{ hasTitle: false },
+		);
+	}
+
+	createTestComposite(): TestComposite {
+		return this.createComposite(TestComposite.ID);
+	}
+
+	removeTestComposite(): boolean {
+		return this.removeComposite(TestComposite.ID);
+	}
+
+	hasCompositeOpenListeners(): boolean {
+		return this.onDidCompositeOpen.hasListeners();
+	}
+
+	toJSON(): object {
+		return {};
+	}
+}
+
+suite('CompositePart', () => {
+
+	const disposables = new DisposableStore();
+	let fixture: HTMLElement;
+
+	setup(() => {
+		fixture = document.createElement('div');
+		document.body.appendChild(fixture);
+	});
+
+	teardown(() => {
+		fixture.remove();
+		disposables.clear();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('removing a composite disposes its progress scope listeners', () => {
+		const storageService = disposables.add(new TestStorageService());
+		const themeService = new TestThemeService();
+		const instantiationService = disposables.add(new TestInstantiationService(new ServiceCollection(
+			[ITelemetryService, NullTelemetryService],
+			[IThemeService, themeService],
+			[IStorageService, storageService],
+		)));
+		const registry = disposables.add(new TestCompositeRegistry());
+		registry.register(new TestCompositeDescriptor());
+		const part = disposables.add(new TestCompositePart(
+			instantiationService,
+			registry,
+			storageService,
+			themeService,
+			new TestLayoutService(),
+		));
+		part.create(fixture);
+
+		part.createTestComposite();
+		assert.strictEqual(part.hasCompositeOpenListeners(), true);
+
+		assert.strictEqual(part.removeTestComposite(), true);
+		assert.strictEqual(part.hasCompositeOpenListeners(), false);
+	});
+});


### PR DESCRIPTION
### Details

Moving Run and Debug to the panel and resetting its location leaves event listeners behind. This keeps the old Run and Debug view in memory.

### Change

Dispose the progress scope, progress indicator and child instantiation service when the composite is removed.

### Before

When moving the Run and Debug view to the panel and resetting its location 37 times, the view and related callbacks grow:

<img width="1400" height="1360" alt="before" src="https://github.com/user-attachments/assets/7715471c-d215-400e-82f2-f8ea49f70d42" />

### After

No more matching leak is detected.

### Test Video

[test-video.webm](https://github.com/user-attachments/assets/2c77cf10-d2c9-458e-babb-fa0b2e2ef37a)
